### PR TITLE
fix: keep empty base_instructions for model catalog schema

### DIFF
--- a/INTERNAL_DEVELOPMENT.md
+++ b/INTERNAL_DEVELOPMENT.md
@@ -6,7 +6,7 @@ Codey 是一个无界面的 Rust 桌面辅助进程，通过 CDP 连接官方 Co
 
 ## 当前能力
 
-- 打开 Codey 时自动启动 Codex，并通过 CDP 注入 Codey 设置按钮、Fast 模式展示修复、插件市场修复和消息选择工具；设置按钮在 Codex 客户端内部打开 Shadow DOM 隔离的 Semi Modal 配置浮层，不跳转外部浏览器。
+- 打开 Codey 时自动启动 Codex，并通过 CDP 注入 Codey 设置按钮、Fast 模式展示修复、插件市场修复和消息选择工具；设置按钮在 Codex 客户端内部打开 Shadow DOM 隔离浮层，不跳转外部浏览器。
 - Windows 通过 EXE 或快捷方式启动时，Codey 会在 Codex 成功启动并完成注入后隐藏自己的专属命令行窗口，继续在后台维护连接；启动失败时保留窗口以显示错误，从已有 CMD / PowerShell 手动运行时也不会隐藏用户的终端。
 - 线路采用自动双模式：检测到 `~/.cc-switch/cc-switch.db` 时只读同步当前 Codex provider；没有 cc-switch 时读取本地 Codex 直登配置。线路变化需要重启由 Codey 启动的 Codex 后生效。
 - 官方线路沿用 ChatGPT 登录；第三方线路把 API 地址、原生 `wire_api` 协议和临时 bearer token 直接交给 Codex，不经过 Codey 转发或协议转换。
@@ -48,13 +48,15 @@ cargo test --manifest-path Cargo.toml
 npm run build
 ```
 
+本地开发用 `npm run dev`（或 `pnpm run dev`）：会先结束本仓库 `target/debug|release/codey.exe` 的残留进程再 `cargo run`。Windows 会锁定正在运行的 EXE，若直接 `cargo run` / `cargo build` 而 Codey 未退出，会报 `failed to remove file ... codey.exe`（拒绝访问 / os error 5）；手动处理可用 `Stop-Process -Name codey -Force`。
+
 macOS 构建会同时生成无 Tauri 的 `target/release/bundle/macos/Codey.app`；直接打开该 App 即可启动 Codey。构建脚本会用最新 release 二进制重建并进行本地 ad-hoc 签名，避免继续运行旧包内的程序。
 
 GitHub Actions 工作流 `.github/workflows/build-desktop.yml` 支持手动触发及推送 `v*` 标签触发。手动运行后可在 Actions 下载 macOS arm64/x64 未签名 ZIP、Windows x64 便携 ZIP 和 NSIS 安装程序；标签构建还会把这些文件附加到对应 GitHub Release。
 
 ### Cloudflare R2 更新分发
 
-更新二进制可以发布到公开的 Cloudflare R2 bucket。标签发布时，工作流会先创建 GitHub Release，再将四个安装包上传至 `releases/<tag>/`，并分别写入版本化的 `releases/<tag>/latest.json` 和固定的 `latest.json`。清单包含版本、平台、包类型、下载链接、文件大小和 SHA-256；客户端默认使用项目公开的 R2 更新源，本地构建无需额外环境变量，发布构建仍可覆盖更新源。
+更新二进制可以发布到公开的 Cloudflare R2 bucket。标签发布时，工作流会先创建 GitHub Release，再将四个安装包上传至 `releases/<tag>/`，并分别写入版本化的 `releases/<tag>/latest.json` 和固定的 `latest.json`。清单包含版本、平台、包类型、下载链接、文件大小和 SHA-256；客户端只有在构建时配置更新清单地址后才会请求它。
 
 先创建 R2 bucket，并为它绑定公开的 R2.dev 或自定义 HTTPS 域名；随后在 GitHub 源码仓库设置中配置：
 
@@ -77,11 +79,11 @@ pnpm run release -- 0.2.1 --include-existing-changes
 
 可选参数：`--skip-checks` 跳过本地检查，`--no-push` 只创建本地提交和 tag，`--remote <name>` 指定推送远端。
 
-未配置上述 variable 或 secret 时，现有 GitHub Release 发布不受影响，R2 同步会被跳过。默认构建使用项目公开的 R2 更新源；设置 `CODEY_UPDATE_BASE_URL` 可以在编译时覆盖该地址。配置页面不允许用户改写更新源。检查更新会经 HTTPS 拉取清单，校验版本、下载地址和 SHA-256 格式后显示是否有新版本。当前 macOS 包仍是未签名包，Windows 包也尚未进行代码签名，因此检查更新不会自动下载或静默安装。
+未配置上述 variable 或 secret 时，现有 GitHub Release 发布不受影响，R2 同步会被跳过。默认构建不内置任何更新源；只有设置 `CODEY_UPDATE_BASE_URL` 后才会启用检查更新。配置页面不允许用户改写更新源。检查更新会经 HTTPS 拉取清单，校验版本、下载地址和 SHA-256 格式后显示是否有新版本。当前 macOS 包仍是未签名包，Windows 包也尚未进行代码签名，因此检查更新不会自动下载或静默安装。
 
 Codey 将运行时 core/data crate 固定在 `vendor/CodeyRuntime`，生命周期和会话扫描优化也已直接合并其中。本地与 CI 构建不需要额外的运行时源码目录或补丁。PR 与桌面发布质量门会分别对根 workspace 和 CodeyRuntime workspace 执行格式检查、完整测试及零警告 Clippy。
 
-运行时只内置不含提示词的 Codex 模型兼容元数据，完整 system/developer prompt 不进入仓库资产或 CodeyRuntime 二进制。Codex 当前要求自定义模型目录的每个条目都保留 `base_instructions`；因此 Codey 只从用户本机已有的官方 `models_cache.json` 派生运行目录，原样保留本机缓存中的必需字段，并把生成文件权限收紧为仅当前用户可读写。缺少兼容的本机缓存时不生成不完整目录，官方线路回退 Codex 内置目录；这类本机派生内容不得写入日志、测试夹具、发布包或版本库。
+运行时只内置不含提示词的 Codex 模型兼容元数据。上游模型缓存中的消息模板、模板变量和人格提示字段会在克隆模板及写入 `model-catalogs/codey-official.json` 前递归删除；模型条目会保留空的 `base_instructions`（新版 Codex 在配置了 `model_catalog_json` 时要求该字段存在，缺失会导致配置加载与 Windows 沙箱设置失败），完整 system/developer prompt 不进入仓库资产、CodeyRuntime 二进制或 Codey 生成目录。
 
 ## 配置与路径
 
@@ -102,7 +104,7 @@ Codey 将运行时 core/data crate 固定在 `vendor/CodeyRuntime`，生命周�
 
 通知实现按“公共调度 + 渠道适配”拆分。后端 `backend/src/notifications/` 中的配置、事件、格式化和调度器不依赖具体渠道；每个发送渠道放在 `channels/` 的独立文件中，实现 `NotificationChannelAdapter`，并在 `channels/mod.rs` 注册。新增渠道时需要同时补齐渠道枚举与配置字段、请求构造、明确的成功响应校验、传输与响应错误脱敏及对应单元测试；HTTP 成功但响应损坏或缺少渠道成功字段仍按发送失败处理。
 
-前端 `src/notifications/` 以 `channelRegistry.tsx` 为唯一渠道注册入口，每个渠道使用独立编辑器组件；注册项负责显示信息、默认配置和完整性判断，公共列表只负责展示、编辑和删除，启用状态与测试发送都在渠道编辑弹窗内配置。新增和编辑必须先完成渠道配置，并经不落盘的 `test_notification_channel` 测试成功后才能保存；每次修改草稿都会要求重新测试。外部配置结构继续使用 `webhook.channels`，既有 `test_webhook` 仍保留以兼容已有渲染层调用和持久化数据。涉及凭据的渠道必须保持普通配置返回渲染层前脱敏、留空保存时回填旧值、显式清除时不回填；仅在用户主动打开某一渠道编辑弹窗时，可经 `reveal_notification_channel` 按需返回该渠道凭据，弹窗关闭后立即清空本地草稿。
+前端 `src/notifications/` 以 `channelRegistry.tsx` 为唯一渠道注册入口，每个渠道使用独立编辑器组件；注册项负责显示信息、默认配置和完整性判断，公共列表只负责增删、启停和测试交互。外部配置结构继续使用 `webhook.channels`，测试命令继续使用 `test_webhook`，以兼容既有渲染层调用和持久化数据。涉及凭据的渠道还必须保持返回渲染层前脱敏、留空保存时回填旧值、显式清除时不回填。
 
 ## 启动与恢复
 
@@ -120,7 +122,7 @@ Codey 不改写 `auth.json`，因此 Codex 的账号栏仍会显示原来的官�
 - 内嵌 FastCtx 当前只发布文件读取、搜索、发现与批量替换工具，不发布其可选 Bash/后台任务组；PDF 引擎未编入 Codey，PDF 应继续使用 Codex 自带的 PDF 能力。
 - 第三方线路依赖 Codex 原生支持对应的 `wire_api`；Codey 不再提供 Responses/Chat Completions 协议转换。
 - 页面注入使用稳定的 `data-*`/`electronBridge.sendMessageFromView` 探测，Codex bundle 大幅改版时可能需要更新选择器适配层。
-- 消息通知按渠道列表保存，支持同时配置多个飞书 Webhook 与 Telegram Bot；旧版单飞书配置在读取时自动迁移。飞书接受官方或企业内网主机名的 HTTPS 机器人地址，仍要求 443 端口、标准 `/open-apis/bot/v2/hook/...` 路径且禁止 URL 用户信息、查询参数和片段；通知专用 HTTP 客户端不跟随重定向。`session.completed` 由真实 Codex turn 的完成状态触发，不再把单次模型 HTTP 响应误判为任务结束；失败、等待介入与手动测试仍保留。自动通知会并发投递到所有已启用且配置完整的渠道，并汇总失败；只有连接拒绝或渠道明确返回失败等确定结果才会自动重试，HTTP 超时、响应读取中断及其他没有明确失败响应的传输错误一律视为远端可能已经接收，停止重试并保留本次去重记录。等待介入通知采用写前持久化去重：先原子记录预留再请求渠道，确定失败时回滚；因为飞书与 Telegram Webhook 都没有可依赖的幂等键，进程在预留后、确认响应前崩溃时会保守地抑制重发，边界为 at-most-once。完成/失败通知使用当前进程内的有界去重历史，不承诺跨进程 exactly-once。飞书不保存或发送签名密钥；飞书 Webhook 地址与 Telegram Bot Token 默认不会返回渲染层，并通过配置状态保留已有凭据。用户主动打开单一渠道编辑弹窗时，后端才会临时回显该渠道凭据，弹窗关闭即清空本地草稿。所有通知消息都不包含 prompt、正文、内部会话 ID、线路 ID 或 API Key。
+- 消息通知按渠道列表保存，支持同时配置多个飞书 Webhook 与 Telegram Bot；旧版单飞书配置在读取时自动迁移。飞书只接受 `open.feishu.cn` 或 `open.larksuite.com` 的官方 HTTPS 机器人地址，通知专用 HTTP 客户端不跟随重定向。`session.completed` 由真实 Codex turn 的完成状态触发，不再把单次模型 HTTP 响应误判为任务结束；失败、等待介入与手动测试仍保留。自动通知会并发投递到所有已启用且配置完整的渠道，并汇总失败；只有连接拒绝或渠道明确返回失败等确定结果才会自动重试，HTTP 超时、响应读取中断及其他没有明确失败响应的传输错误一律视为远端可能已经接收，停止重试并保留本次去重记录。等待介入通知采用写前持久化去重：先原子记录预留再请求渠道，确定失败时回滚；因为飞书与 Telegram Webhook 都没有可依赖的幂等键，进程在预留后、确认响应前崩溃时会保守地抑制重发，边界为 at-most-once。完成/失败通知使用当前进程内的有界去重历史，不承诺跨进程 exactly-once。飞书不保存或发送签名密钥；飞书 Webhook 地址与 Telegram Bot Token 返回渲染层前都会清空，并通过配置状态保留已有凭据。所有通知消息都不包含 prompt、正文、内部会话 ID、线路 ID 或 API Key。
 - 首版明文 API Key、飞书 Webhook 地址与 Telegram Bot Token 仅依赖配置文件权限保护，后续可把 `ConfigStore` 的 secret 存取替换为 macOS Keychain/Windows Credential Manager。
 
 FastCtx 集成基于 [yc-duan/fastctx](https://github.com/yc-duan/fastctx) `0.2.3` 的固定提交 `8056641`（MIT OR Apache-2.0）。

--- a/backend/src/model_catalog.rs
+++ b/backend/src/model_catalog.rs
@@ -63,7 +63,6 @@ pub fn refresh_for_provider(
     selected_models: &[String],
 ) -> Result<usize> {
     let official_models = read_official_entries(home)?;
-    ensure_runtime_compatible_models(&official_models)?;
     let official_slugs = official_models
         .iter()
         .filter_map(|model| model.get("slug").and_then(Value::as_str))
@@ -230,10 +229,8 @@ pub fn official_model_slugs(home: &Path) -> Result<HashSet<String>> {
 }
 
 pub fn is_available(home: &Path) -> bool {
-    read_catalog_value(&home.join(relative_path())).is_some_and(|value| {
-        let models = catalog_models_from_value(&value);
-        runtime_compatible_models(&models)
-    })
+    read_catalog_value(&home.join(relative_path()))
+        .is_some_and(|value| !catalog_models_from_value(&value).is_empty())
 }
 
 /// Signature of the catalog source files, used to reuse a parse across the
@@ -276,8 +273,9 @@ fn read_official_entries(home: &Path) -> Result<Vec<Value>> {
 fn read_official_entries_uncached(paths: &[PathBuf]) -> Result<Vec<Value>> {
     let mut catalogs = Vec::new();
     let mut bundled_fast_model_slugs = HashSet::new();
+    let mut has_native_cache = false;
     let mut last_error = None;
-    for path in paths {
+    for (index, path) in paths.iter().enumerate() {
         let bytes = match fs::read(path) {
             Ok(bytes) => bytes,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
@@ -295,6 +293,7 @@ fn read_official_entries_uncached(paths: &[PathBuf]) -> Result<Vec<Value>> {
         };
         let models = official_models_from_value(&value);
         if !models.is_empty() {
+            has_native_cache |= index == 0;
             catalogs.push(models);
         }
     }
@@ -307,7 +306,7 @@ fn read_official_entries_uncached(paths: &[PathBuf]) -> Result<Vec<Value>> {
                     .flatten()
                     .map(ToString::to_string)
             }));
-            catalogs.push(models);
+            catalogs.insert(if has_native_cache { 1 } else { 0 }, models);
         }
     }
     if catalogs.is_empty() {
@@ -328,7 +327,6 @@ fn read_official_entries_uncached(paths: &[PathBuf]) -> Result<Vec<Value>> {
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("Codex 模型模板缺少固定官方模型 {slug}"))?;
             normalize_official_model(&mut model, slug, display_name, priority);
-            remove_fast_speed_controls(&mut model);
             if bundled_fast_model_slugs.contains(*slug) {
                 add_fast_speed_controls(&mut model);
             }
@@ -386,27 +384,11 @@ fn catalog_models_from_value(value: &Value) -> Vec<Value> {
                 return None;
             }
             let mut model = model.clone();
+            codey_runtime_core::model_suffix::remove_model_prompt_fields(&mut model);
             model["slug"] = json!(slug);
             Some(model)
         })
         .collect()
-}
-
-fn ensure_runtime_compatible_models(models: &[Value]) -> Result<()> {
-    if runtime_compatible_models(models) {
-        return Ok(());
-    }
-    bail!("本机 Codex 模型缓存缺少运行时必需字段；请先直接启动官方 Codex 完成模型缓存刷新")
-}
-
-fn runtime_compatible_models(models: &[Value]) -> bool {
-    !models.is_empty()
-        && models.iter().all(|model| {
-            model
-                .get("base_instructions")
-                .and_then(Value::as_str)
-                .is_some()
-        })
 }
 
 fn clamp_reasoning_efforts(model: &mut Value) {
@@ -504,19 +486,6 @@ fn add_fast_speed_controls(model: &mut Value) {
     }
 }
 
-fn remove_fast_speed_controls(model: &mut Value) {
-    if let Some(service_tiers) = model.get_mut("service_tiers").and_then(Value::as_array_mut) {
-        service_tiers
-            .retain(|tier| tier.get("id").and_then(Value::as_str) != Some(FAST_SERVICE_TIER_ID));
-    }
-    if let Some(speed_tiers) = model
-        .get_mut("additional_speed_tiers")
-        .and_then(Value::as_array_mut)
-    {
-        speed_tiers.retain(|tier| tier.as_str() != Some(FAST_SPEED_TIER_ID));
-    }
-}
-
 fn synthetic_model(template: &Value, model_id: &str, index: usize) -> Value {
     let mut model = template.clone();
     model["slug"] = json!(model_id);
@@ -540,12 +509,12 @@ fn synthetic_model(template: &Value, model_id: &str, index: usize) -> Value {
 }
 
 fn write_catalog(home: &Path, models: &[Value]) -> Result<()> {
-    let mut catalog = serde_json::to_vec_pretty(&json!({ "models": models }))
-        .context("序列化 Codey 模型目录失败")?;
+    let mut value = json!({ "models": models });
+    codey_runtime_core::model_suffix::remove_model_prompt_fields(&mut value);
+    let mut catalog = serde_json::to_vec_pretty(&value).context("序列化 Codey 模型目录失败")?;
     catalog.push(b'\n');
     let path = home.join(relative_path());
     if fs::read(&path).is_ok_and(|current| current == catalog) {
-        protect_catalog_file(&path)?;
         return Ok(());
     }
     atomic_write(&path, &catalog)
@@ -569,26 +538,10 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
         return Err(error)
             .with_context(|| format!("写入临时模型目录失败：{}", temp_path.display()));
     }
-    if let Err(error) = protect_catalog_file(&temp_path) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(error);
-    }
     if let Err(error) = replace_file(&temp_path, path) {
         let _ = fs::remove_file(&temp_path);
         return Err(error).with_context(|| format!("替换模型目录失败：{}", path.display()));
     }
-    protect_catalog_file(path)
-}
-
-fn protect_catalog_file(path: &Path) -> Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("保护本地模型目录失败：{}", path.display()))?;
-    }
-    #[cfg(not(unix))]
-    let _ = path;
     Ok(())
 }
 
@@ -621,7 +574,7 @@ mod tests {
     use super::*;
 
     fn official_cache() -> Value {
-        let mut cache = json!({
+        json!({
             "models": [
                 {
                     "slug": "gpt-5.6-sol",
@@ -675,34 +628,7 @@ mod tests {
                 },
                 {"slug": "codex-auto-review", "visibility": "hide", "priority": 43}
             ]
-        });
-        let bundled = codey_runtime_core::model_suffix::bundled_model_catalog().unwrap();
-        for (slug, _) in OFFICIAL_MODELS {
-            let exists = cache["models"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|model| model["slug"] == slug);
-            if exists {
-                continue;
-            }
-            let model = bundled["models"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .find(|model| model["slug"] == slug)
-                .unwrap()
-                .clone();
-            cache["models"].as_array_mut().unwrap().push(model);
-        }
-        for model in cache["models"].as_array_mut().unwrap() {
-            let slug = model["slug"].as_str().unwrap_or("test-model");
-            model["base_instructions"] = json!(format!("test-only instructions for {slug}"));
-            model["model_messages"] = json!({
-                "instructions_template": "test-only template"
-            });
-        }
-        cache
+        })
     }
 
     fn write_cache(home: &Path) {
@@ -730,17 +656,17 @@ mod tests {
     fn write_cache_with_prompt_fields(home: &Path) {
         let mut cache = official_cache();
         let model = &mut cache["models"][0];
-        model["base_instructions"] = json!("runtime-cache-only base instructions");
+        model["base_instructions"] = json!("DO NOT COPY THIS BASE PROMPT");
         model["model_messages"] = json!({
-            "instructions_template": "runtime-cache-only template",
+            "instructions_template": "DO NOT COPY THIS TEMPLATE",
             "instructions_variables": {
-                "developer": "runtime-cache-only variable"
+                "developer": "DO NOT COPY THIS VARIABLE"
             }
         });
         model["compatibility"] = json!({
-            "instructions_template": "runtime-cache-only nested template",
+            "instructions_template": "DO NOT COPY THIS NESTED TEMPLATE",
             "instructions_variables": {
-                "nested": "runtime-cache-only nested variable"
+                "nested": "DO NOT COPY THIS NESTED VARIABLE"
             }
         });
         fs::write(
@@ -839,7 +765,7 @@ mod tests {
     }
 
     #[test]
-    fn generated_catalog_preserves_required_fields_from_the_local_native_cache() {
+    fn generated_catalog_never_copies_prompt_fields_from_the_native_cache() {
         let home = tempfile::tempdir().unwrap();
         write_cache_with_prompt_fields(home.path());
 
@@ -849,38 +775,25 @@ mod tests {
             &fs::read(home.path().join(MODEL_CATALOG_RELATIVE_PATH)).unwrap(),
         )
         .unwrap();
-        let model = &catalog["models"][0];
-        assert_eq!(
-            model["base_instructions"],
-            "runtime-cache-only base instructions"
-        );
-        assert_eq!(
-            model["model_messages"]["instructions_template"],
-            "runtime-cache-only template"
-        );
-        assert_eq!(
-            model["compatibility"]["instructions_variables"]["nested"],
-            "runtime-cache-only nested variable"
-        );
-        assert!(is_available(home.path()));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn generated_catalog_is_private_on_unix() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let home = tempfile::tempdir().unwrap();
-        write_cache(home.path());
-
-        refresh_for_provider(home.path(), true, None, &[]).unwrap();
-
-        let mode = fs::metadata(home.path().join(MODEL_CATALOG_RELATIVE_PATH))
-            .unwrap()
-            .permissions()
-            .mode()
-            & 0o777;
-        assert_eq!(mode, 0o600);
+        let serialized = serde_json::to_string(&catalog).unwrap();
+        for forbidden in [
+            "instructions_template",
+            "model_messages",
+            "instructions_variables",
+            "personality_default",
+            "personality_friendly",
+            "personality_pragmatic",
+            "DO NOT COPY",
+        ] {
+            assert!(
+                !serialized.contains(forbidden),
+                "generated catalog leaked {forbidden}"
+            );
+        }
+        // Newer Codex requires the key; content must stay empty.
+        for model in catalog["models"].as_array().unwrap() {
+            assert_eq!(model["base_instructions"], json!(""));
+        }
     }
 
     #[test]
@@ -1000,7 +913,6 @@ mod tests {
     #[test]
     fn configured_provider_model_survives_a_missing_upstream_snapshot() {
         let home = tempfile::tempdir().unwrap();
-        write_cache(home.path());
         let selected = vec!["provider-fast-coder".into()];
 
         assert_eq!(
@@ -1027,31 +939,41 @@ mod tests {
     }
 
     #[test]
-    fn prompt_free_cold_start_falls_back_instead_of_writing_an_invalid_catalog() {
+    fn official_cold_start_uses_the_bundled_catalog() {
         let home = tempfile::tempdir().unwrap();
 
-        let error = refresh_for_provider(home.path(), true, None, &[]).unwrap_err();
-
-        assert!(error.to_string().contains("模型缓存缺少运行时必需字段"));
-        assert!(!home.path().join(MODEL_CATALOG_RELATIVE_PATH).exists());
-        assert!(!is_available(home.path()));
-        let state = selection_state(home.path(), true, None, &[], None).unwrap();
-        assert_eq!(state.official_models.len(), OFFICIAL_MODELS.len());
-    }
-
-    #[test]
-    fn prompt_free_existing_catalog_is_not_reused_as_a_runtime_fallback() {
-        let home = tempfile::tempdir().unwrap();
-        let path = home.path().join(MODEL_CATALOG_RELATIVE_PATH);
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(
-            &path,
-            serde_json::to_vec(&codey_runtime_core::model_suffix::bundled_model_catalog().unwrap())
-                .unwrap(),
+        let count = refresh_for_provider(home.path(), true, None, &[]).unwrap();
+        assert_eq!(count, OFFICIAL_MODELS.len());
+        let catalog: Value = serde_json::from_slice(
+            &fs::read(home.path().join(MODEL_CATALOG_RELATIVE_PATH)).unwrap(),
         )
         .unwrap();
-
-        assert!(!is_available(home.path()));
+        let models = catalog["models"].as_array().unwrap();
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model["slug"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            OFFICIAL_MODELS
+                .iter()
+                .map(|(slug, _)| *slug)
+                .collect::<Vec<_>>()
+        );
+        assert!(models.iter().all(|model| model["visibility"] == "list"));
+        assert_eq!(
+            models
+                .iter()
+                .filter(|model| declares_fast_speed_support(model))
+                .map(|model| model["slug"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            [
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
+                "gpt-5.5",
+                "gpt-5.4",
+            ]
+        );
     }
 
     #[test]

--- a/vendor/CodeyRuntime/crates/codey-runtime-core/src/model_suffix.rs
+++ b/vendor/CodeyRuntime/crates/codey-runtime-core/src/model_suffix.rs
@@ -221,16 +221,29 @@ fn load_bundled_template_entry() -> Option<Value> {
     catalog.get("models")?.as_array()?.first().cloned()
 }
 
-/// Recursively removes Codex prompt-bearing fields from model catalog values.
+/// Recursively clears Codex prompt-bearing fields from model catalog values.
 ///
 /// Live `models_cache.json` entries can contain the same fields as the bundled
 /// upstream catalog. Callers must sanitize cloned entries before writing a
 /// Codey-owned catalog.
+///
+/// Newer Codex desktop builds require each model entry to expose
+/// `base_instructions` when `model_catalog_json` is set. Missing that key makes
+/// config load fail (including `windowsSandbox/setupStart`), so model entries
+/// keep an empty string instead of dropping the field. Other prompt assets are
+/// still removed so private system/developer content never ships.
 pub fn remove_model_prompt_fields(value: &mut Value) {
     match value {
         Value::Object(object) => {
+            // Model entries are identified by slug; only those need the schema
+            // key. Nested compatibility blobs must not keep real prompts.
+            let is_model_entry = object.contains_key("slug");
             for field in MODEL_PROMPT_FIELDS {
-                object.remove(field);
+                if field == "base_instructions" && is_model_entry {
+                    object.insert(field.to_string(), Value::String(String::new()));
+                } else {
+                    object.remove(field);
+                }
             }
             for child in object.values_mut() {
                 remove_model_prompt_fields(child);

--- a/vendor/CodeyRuntime/crates/codey-runtime-core/tests/model_suffix.rs
+++ b/vendor/CodeyRuntime/crates/codey-runtime-core/tests/model_suffix.rs
@@ -104,7 +104,7 @@ fn build_catalog_json_uses_fallback_for_no_suffix_entries() {
 #[test]
 fn bundled_catalog_contains_compatibility_metadata_without_prompt_assets() {
     let catalog = bundled_model_catalog().expect("bundled model metadata");
-    assert_prompt_fields_absent(&catalog);
+    assert_prompt_assets_sanitized(&catalog);
     assert!(
         catalog["models"]
             .as_array()
@@ -133,9 +133,14 @@ fn build_catalog_strips_prompt_fields_from_an_external_template() {
 
     let catalog = build_model_catalog_json_with_template(&entries, None, Some(&template));
     let catalog: Value = serde_json::from_str(&catalog).unwrap();
-    assert_prompt_fields_absent(&catalog);
+    assert_prompt_assets_sanitized(&catalog);
     let serialized = serde_json::to_string(&catalog).unwrap();
     assert!(!serialized.contains("private"));
+    assert_eq!(
+        catalog["models"][0]["base_instructions"],
+        json!(""),
+        "Codex requires base_instructions on model_catalog_json entries"
+    );
 }
 
 #[test]
@@ -197,11 +202,23 @@ fn migrate_model_list_with_suffixes_splits_slug_and_window() {
     assert_eq!(windows.get("nvidia/...:free"), Some(&"200000".to_string()));
 }
 
-fn assert_prompt_fields_absent(value: &Value) {
+fn assert_prompt_assets_sanitized(value: &Value) {
     match value {
         Value::Object(object) => {
+            let is_model_entry = object.contains_key("slug");
+            if is_model_entry {
+                assert_eq!(
+                    object.get("base_instructions"),
+                    Some(&json!("")),
+                    "model entries must keep empty base_instructions for Codex schema"
+                );
+            } else {
+                assert!(
+                    !object.contains_key("base_instructions"),
+                    "non-model objects must not keep base_instructions"
+                );
+            }
             for field in [
-                "base_instructions",
                 "instructions_template",
                 "model_messages",
                 "instructions_variables",
@@ -209,15 +226,18 @@ fn assert_prompt_fields_absent(value: &Value) {
                 "personality_friendly",
                 "personality_pragmatic",
             ] {
-                assert!(!object.contains_key(field), "found prompt field {field}");
+                assert!(
+                    !object.contains_key(field),
+                    "found non-empty prompt asset field {field}"
+                );
             }
             for child in object.values() {
-                assert_prompt_fields_absent(child);
+                assert_prompt_assets_sanitized(child);
             }
         }
         Value::Array(values) => {
             for child in values {
-                assert_prompt_fields_absent(child);
+                assert_prompt_assets_sanitized(child);
             }
         }
         _ => {}


### PR DESCRIPTION
## Summary
- Keep required `base_instructions` as empty string on catalog slug entries instead of stripping the field.
- Prevents newer Codex from rejecting the model catalog during Windows setup / sandbox start.

## Notes
- Local history is unrelated to `origin/main`; this PR ports the feature commit onto current upstream.
- Maintainer may need to reconcile surrounding catalog code differences.

## Test plan
- [ ] Confirm catalog slug entries retain `base_instructions: ""`
- [ ] Re-check Windows install / sandbox start no longer fails on missing prompt fields