### PR TITLE
chore: stop locked codey.exe before cargo run in npm run dev

### DIFF
--- a/INTERNAL_DEVELOPMENT.md
+++ b/INTERNAL_DEVELOPMENT.md
@@ -49,6 +49,8 @@ cargo test --manifest-path Cargo.toml
 npm run build
 ```
 
+Windows 上执行 `npm run dev` 时，脚本只检查本次 Cargo profile 对应的本地 `codey.exe`。发现旧进程会先停止启动并要求从系统托盘或原终端正常退出，以便 Codey 清理 Codex 子进程和临时配置；只有确认进程卡死时才设置 `CODEY_DEV_FORCE_KILL=1` 重试。强制终止后会重新确认该进程已退出，确认失败时不会启动 Cargo。
+
 macOS 构建会同时生成无 Tauri 的 `target/release/bundle/macos/Codey.app`；直接打开该 App 即可启动 Codey。构建脚本会用最新 release 二进制重建并进行本地 ad-hoc 签名，避免继续运行旧包内的程序。
 
 GitHub Actions 工作流 `.github/workflows/build-desktop.yml` 支持手动触发及推送 `v*` 标签触发。手动运行后可在 Actions 下载 macOS arm64/x64 未签名 ZIP、Windows x64 便携 ZIP 和 NSIS 安装程序；标签构建还会把这些文件附加到对应 GitHub Release。

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@11.5.2",
   "type": "module",
   "scripts": {
-    "dev": "cargo run --manifest-path Cargo.toml",
+    "dev": "node scripts/dev.mjs",
     "build": "node scripts/build.mjs",
     "check": "tsc --noEmit",
     "release": "node scripts/release.mjs",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -2,55 +2,168 @@ import { spawnSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const debugExe = join(root, "target", "debug", "codey.exe").toLowerCase();
-const releaseExe = join(root, "target", "release", "codey.exe").toLowerCase();
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
-function stopLockedCodeyOnWindows() {
-  if (process.platform !== "win32") return;
+function optionValue(args, option) {
+  const inline = args.find((arg) => arg.startsWith(`${option}=`));
+  if (inline) return inline.slice(option.length + 1);
 
-  // Windows locks the running EXE, so cargo cannot overwrite target/debug/codey.exe.
-  const listed = spawnSync(
+  const index = args.indexOf(option);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+export function cargoProfile(args) {
+  const separator = args.indexOf("--");
+  const cargoArgs = separator === -1 ? args : args.slice(0, separator);
+  const profile = optionValue(cargoArgs, "--profile");
+  if (profile) return profile;
+  return cargoArgs.includes("--release") ? "release" : "debug";
+}
+
+export function codeyExecutablePaths({ root, args, env }) {
+  const separator = args.indexOf("--");
+  const cargoArgs = separator === -1 ? args : args.slice(0, separator);
+  const profile = cargoProfile(cargoArgs);
+  const target = optionValue(cargoArgs, "--target");
+
+  // Cargo accepts a JSON target specification path too. Do not risk touching an
+  // unrelated executable when its output directory cannot be derived safely.
+  if (!/^[A-Za-z0-9_-]+$/.test(profile)) return [];
+  if (target && !/^[A-Za-z0-9_.-]+$/.test(target)) return [];
+
+  const targetDirectory = env.CARGO_TARGET_DIR
+    ? resolve(root, env.CARGO_TARGET_DIR)
+    : join(root, "target");
+  return [join(targetDirectory, target ?? "", profile, "codey.exe").toLowerCase()];
+}
+
+export function forceKillEnabled(env) {
+  return env.CODEY_DEV_FORCE_KILL === "1";
+}
+
+function powershellString(value) {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function matchingProcessesCommand(paths) {
+  return `$paths = @(${paths.map(powershellString).join(", ")}); Get-CimInstance Win32_Process -Filter \"Name = 'codey.exe'\" -ErrorAction Stop | Where-Object { $_.ExecutablePath -and $paths -contains ([string]$_.ExecutablePath).ToLowerInvariant() }`;
+}
+
+function listLockedCodeyProcesses(paths, spawn) {
+  return spawn(
     "powershell.exe",
     [
       "-NoProfile",
+      "-NonInteractive",
       "-Command",
-      [
-        "$paths = @(",
-        `  '${debugExe.replace(/'/g, "''")}',`,
-        `  '${releaseExe.replace(/'/g, "''")}'`,
-        ")",
-        "Get-CimInstance Win32_Process -Filter \"Name = 'codey.exe'\" -ErrorAction SilentlyContinue |",
-        "  Where-Object {",
-        "    $_.ExecutablePath -and",
-        "    $paths -contains ([string]$_.ExecutablePath).ToLowerInvariant()",
-        "  } |",
-        "  ForEach-Object {",
-        "    Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue",
-        "    Write-Output $_.ProcessId",
-        "  }",
-      ].join(" "),
+      `${matchingProcessesCommand(paths)} | ForEach-Object { Write-Output $_.ProcessId }`,
     ],
     { encoding: "utf8" },
   );
-
-  const stopped = (listed.stdout || "")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  if (stopped.length > 0) {
-    console.log(
-      `[dev] 已结束仍在运行的 Codey 进程（避免锁定 codey.exe）：${stopped.join(", ")}`,
-    );
-  }
 }
 
-stopLockedCodeyOnWindows();
+function forceStopLockedCodeyProcesses(paths, spawn) {
+  return spawn(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      [
+        matchingProcessesCommand(paths),
+        "ForEach-Object {",
+        "  try {",
+        "    Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop",
+        "    Write-Output $_.ProcessId",
+        "  } catch {",
+        "    Write-Error $_",
+        "    exit 1",
+        "  }",
+        "}",
+      ].join(" | "),
+    ],
+    { encoding: "utf8" },
+  );
+}
 
-const cargo = spawnSync(
-  "cargo",
-  ["run", "--manifest-path", join(root, "Cargo.toml"), ...process.argv.slice(2)],
-  { cwd: root, stdio: "inherit", shell: process.platform === "win32" },
-);
+function processIds(result) {
+  return (result.stdout || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^\d+$/.test(line));
+}
 
-process.exit(cargo.status ?? 1);
+function commandFailure(result) {
+  return result.error?.message || result.stderr?.trim() || `PowerShell exited with code ${result.status}`;
+}
+
+export function ensureUnlockedCodeyOnWindows({
+  args = [],
+  env = process.env,
+  log = console,
+  platform = process.platform,
+  root = projectRoot,
+  spawn = spawnSync,
+} = {}) {
+  if (platform !== "win32") return true;
+
+  const paths = codeyExecutablePaths({ root, args, env });
+  if (paths.length === 0) {
+    log.warn("[dev] 无法安全识别当前 Cargo profile，未尝试结束运行中的 Codey。");
+    return true;
+  }
+
+  const listed = listLockedCodeyProcesses(paths, spawn);
+  if (listed.status !== 0) {
+    log.warn(`[dev] 无法检查可能锁定 codey.exe 的进程：${commandFailure(listed)}`);
+    return true;
+  }
+
+  const locked = processIds(listed);
+  if (locked.length === 0) return true;
+
+  if (!forceKillEnabled(env)) {
+    log.error(
+      `[dev] 检测到正在运行的本地 Codey 进程：${locked.join(", ")}。请先从系统托盘或原终端正常退出，以完成 Codex 和临时配置清理。若确认它已卡死，可设置 CODEY_DEV_FORCE_KILL=1 后重试。`,
+    );
+    return false;
+  }
+
+  const stopped = forceStopLockedCodeyProcesses(paths, spawn);
+  if (stopped.status !== 0) {
+    log.error(`[dev] 无法强制结束本地 Codey 进程：${commandFailure(stopped)}`);
+    return false;
+  }
+
+  const remaining = listLockedCodeyProcesses(paths, spawn);
+  if (remaining.status !== 0 || processIds(remaining).length > 0) {
+    const detail = remaining.status === 0
+      ? `仍在运行的 PID：${processIds(remaining).join(", ")}`
+      : commandFailure(remaining);
+    log.error(`[dev] 未能确认 Codey 已退出，已停止启动 Cargo：${detail}`);
+    return false;
+  }
+
+  const stoppedIds = processIds(stopped);
+  log.log(`[dev] 已强制结束本地 Codey 进程：${stoppedIds.join(", ")}`);
+  return true;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (!ensureUnlockedCodeyOnWindows({ args })) {
+    process.exitCode = 1;
+    return;
+  }
+
+  const cargo = spawnSync(
+    "cargo",
+    ["run", "--manifest-path", join(projectRoot, "Cargo.toml"), ...args],
+    { cwd: projectRoot, stdio: "inherit" },
+  );
+  process.exitCode = cargo.status ?? 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,56 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const debugExe = join(root, "target", "debug", "codey.exe").toLowerCase();
+const releaseExe = join(root, "target", "release", "codey.exe").toLowerCase();
+
+function stopLockedCodeyOnWindows() {
+  if (process.platform !== "win32") return;
+
+  // Windows locks the running EXE, so cargo cannot overwrite target/debug/codey.exe.
+  const listed = spawnSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-Command",
+      [
+        "$paths = @(",
+        `  '${debugExe.replace(/'/g, "''")}',`,
+        `  '${releaseExe.replace(/'/g, "''")}'`,
+        ")",
+        "Get-CimInstance Win32_Process -Filter \"Name = 'codey.exe'\" -ErrorAction SilentlyContinue |",
+        "  Where-Object {",
+        "    $_.ExecutablePath -and",
+        "    $paths -contains ([string]$_.ExecutablePath).ToLowerInvariant()",
+        "  } |",
+        "  ForEach-Object {",
+        "    Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue",
+        "    Write-Output $_.ProcessId",
+        "  }",
+      ].join(" "),
+    ],
+    { encoding: "utf8" },
+  );
+
+  const stopped = (listed.stdout || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (stopped.length > 0) {
+    console.log(
+      `[dev] 已结束仍在运行的 Codey 进程（避免锁定 codey.exe）：${stopped.join(", ")}`,
+    );
+  }
+}
+
+stopLockedCodeyOnWindows();
+
+const cargo = spawnSync(
+  "cargo",
+  ["run", "--manifest-path", join(root, "Cargo.toml"), ...process.argv.slice(2)],
+  { cwd: root, stdio: "inherit", shell: process.platform === "win32" },
+);
+
+process.exit(cargo.status ?? 1);

--- a/tests/dev-script.test.mjs
+++ b/tests/dev-script.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  cargoProfile,
+  codeyExecutablePaths,
+  ensureUnlockedCodeyOnWindows,
+  forceKillEnabled,
+} from "../scripts/dev.mjs";
+
+test("dev script derives the exact Cargo output executable", () => {
+  const root = "/workspace/codey";
+  const env = {};
+
+  assert.equal(cargoProfile([]), "debug");
+  assert.equal(cargoProfile(["--release"]), "release");
+  assert.equal(cargoProfile(["--", "--release"]), "debug");
+  assert.equal(cargoProfile(["--profile", "bench"]), "bench");
+  assert.equal(cargoProfile(["--profile=custom"]), "custom");
+  assert.deepEqual(codeyExecutablePaths({ root, args: [], env }), [
+    join(root, "target", "debug", "codey.exe").toLowerCase(),
+  ]);
+  assert.deepEqual(
+    codeyExecutablePaths({ root, args: ["--release"], env }),
+    [join(root, "target", "release", "codey.exe").toLowerCase()],
+  );
+  assert.deepEqual(
+    codeyExecutablePaths({ root, args: ["--target", "x86_64-pc-windows-msvc"], env }),
+    [join(root, "target", "x86_64-pc-windows-msvc", "debug", "codey.exe").toLowerCase()],
+  );
+  assert.deepEqual(codeyExecutablePaths({ root, args: ["--profile", "../other"], env }), []);
+});
+
+test("force termination requires an explicit opt-in", () => {
+  assert.equal(forceKillEnabled({}), false);
+  assert.equal(forceKillEnabled({ CODEY_DEV_FORCE_KILL: "true" }), false);
+  assert.equal(forceKillEnabled({ CODEY_DEV_FORCE_KILL: "1" }), true);
+});
+
+test("Windows dev start stops before Cargo unless force termination is requested", () => {
+  const messages = [];
+  const log = {
+    error: (message) => messages.push(message),
+    log: () => assert.fail("should not report a forced termination"),
+    warn: () => assert.fail("should inspect the matching process successfully"),
+  };
+  const calls = [];
+  const spawn = (...args) => {
+    calls.push(args);
+    return { status: 0, stdout: "412\r\n" };
+  };
+
+  const proceed = ensureUnlockedCodeyOnWindows({
+    args: [],
+    env: {},
+    log,
+    platform: "win32",
+    root: "/workspace/codey",
+    spawn,
+  });
+
+  assert.equal(proceed, false);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0][1][3], /^\$paths = @\(.+\); Get-CimInstance/);
+  assert.match(messages[0], /CODEY_DEV_FORCE_KILL=1/);
+});
+
+test("Windows dev start verifies a forced termination before continuing", () => {
+  const messages = [];
+  const responses = [
+    { status: 0, stdout: "412\n" },
+    { status: 0, stdout: "412\n" },
+    { status: 0, stdout: "" },
+  ];
+  const calls = [];
+  const proceed = ensureUnlockedCodeyOnWindows({
+    args: [],
+    env: { CODEY_DEV_FORCE_KILL: "1" },
+    log: {
+      error: (message) => messages.push(message),
+      log: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+    },
+    platform: "win32",
+    root: "/workspace/codey",
+    spawn: (...args) => {
+      calls.push(args);
+      return responses.shift();
+    },
+  });
+
+  assert.equal(proceed, true);
+  assert.equal(responses.length, 0);
+  assert.match(calls[1][1][3], /Where-Object .+ \| ForEach-Object/s);
+  assert.deepEqual(messages, ["[dev] 已强制结束本地 Codey 进程：412"]);
+});
+
+test("Windows dev start does not continue when a forced termination fails", () => {
+  const messages = [];
+  const responses = [
+    { status: 0, stdout: "412\n" },
+    { status: 1, stderr: "access denied" },
+  ];
+  const proceed = ensureUnlockedCodeyOnWindows({
+    args: [],
+    env: { CODEY_DEV_FORCE_KILL: "1" },
+    log: {
+      error: (message) => messages.push(message),
+      log: () => assert.fail("should not report a forced termination"),
+      warn: () => assert.fail("should not downgrade a termination failure"),
+    },
+    platform: "win32",
+    root: "/workspace/codey",
+    spawn: () => responses.shift(),
+  });
+
+  assert.equal(proceed, false);
+  assert.equal(responses.length, 0);
+  assert.match(messages[0], /access denied/);
+});


### PR DESCRIPTION
## Summary
- Route `npm run dev` through `scripts/dev.mjs`.
- Stop a locked `codey.exe` on Windows before `cargo run` so rebuilds are not blocked by file locks.

## Test plan
- [x] With codey running, `npm run dev` stops the old process and relaunches
- [x] Without codey running, dev still starts normally