### PR TITLE
chore: clear unused backend imports and dead code warnings

### DIFF
--- a/backend/src/commands/updates.rs
+++ b/backend/src/commands/updates.rs
@@ -1,5 +1,3 @@
-#[cfg(target_os = "macos")]
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -372,6 +370,7 @@ fn spawn_update_installer(update_path: &Path) -> Result<(), String> {
 
 #[cfg(target_os = "macos")]
 fn spawn_update_installer(update_path: &Path) -> Result<(), String> {
+    use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
     if !update_path

--- a/backend/src/launcher.rs
+++ b/backend/src/launcher.rs
@@ -1089,15 +1089,12 @@ async fn spawn_codex(
     experimental_features: ExperimentalFeaturesConfig,
     gpu_launch_mode: GpuLaunchMode,
 ) -> Result<SpawnedCodex> {
-    #[cfg(any(windows, target_os = "macos"))]
     let patch_options = crate::codex_startup_patch::PatchOptions {
         disable_pet: disable_codex_pet,
         disable_voice: disable_codex_voice,
         fast_codex_startup,
         experimental_features,
     };
-    #[cfg(not(any(windows, target_os = "macos")))]
-    let _ = (fast_codex_startup, experimental_features);
     let runtime_arguments = codex_runtime_arguments(gpu_launch_mode, !cfg!(target_os = "macos"));
 
     #[cfg(windows)]
@@ -1337,7 +1334,6 @@ async fn prepare_codex_for_launch(app_dir: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(any(windows, target_os = "macos"))]
 fn startup_patch_detail() -> String {
     #[cfg(windows)]
     {
@@ -1349,6 +1345,7 @@ fn startup_patch_detail() -> String {
     }
 }
 
+#[cfg(not(windows))]
 fn spawn_command(command: Vec<String>) -> Result<SpawnedCodex> {
     let executable = command
         .first()

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -28,7 +28,9 @@ mod update_helper;
 
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+#[cfg(unix)]
+use anyhow::Context;
 
 use commands::{AppShutdownReason, AppState};
 


### PR DESCRIPTION
## Summary
- Silence unused import / dead-code warnings in the Codey backend crate.
- Ported onto `origin/main` from divergent local history; please re-check surrounding files if needed.

## Test plan
- [ ] `cargo build` for backend is warning-clean for these paths