### PR TITLE
feat: harden settings overlay mask, motion, and panel chrome

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import {
   IconLoader2 as LoaderCircle,
   IconX,
 } from "@tabler/icons-react";
-import SemiModal from "@douyinfe/semi-ui/lib/es/modal";
 import { invoke } from "./api";
 import {
   formatBytes,
@@ -35,7 +34,6 @@ import {
   OperationsPanel,
 } from "./AppSections";
 import { NotificationChannelsCard } from "./notifications";
-import type { NotificationChannel } from "./notifications";
 import { errorText, withTimeout } from "./appUtils";
 import { useModelSelection } from "./useModelSelection";
 import { useNotifications } from "./useNotifications";
@@ -56,6 +54,8 @@ import { Badge, Button, Button as SaveButton } from "./components/semi";
 
 const Check = IconCheck;
 const X = IconX;
+/** Fired by the Shadow overlay mask / toggle so App can discard dirty state first. */
+const SETTINGS_REQUEST_CLOSE_EVENT = "codey-settings-request-close";
 
 function CodeyBrandMark() {
   return (
@@ -78,49 +78,6 @@ function CodeyBrandMark() {
   );
 }
 
-type SettingsModalShellProps = {
-  afterClose?: () => void;
-  children: React.ReactNode;
-  container?: HTMLElement | null;
-  header?: React.ReactNode;
-  onCancel: () => void;
-  title?: React.ReactNode;
-  visible: boolean;
-};
-
-function SettingsModalShell({
-  afterClose,
-  children,
-  container,
-  header,
-  onCancel,
-  title,
-  visible,
-}: SettingsModalShellProps) {
-  const headingProps = header === undefined ? { title } : { header };
-  return (
-    <SemiModal
-      {...headingProps}
-      afterClose={afterClose}
-      centered
-      className="codey-settings-modal-layer"
-      closeOnEsc
-      closable={header === undefined}
-      footer={null}
-      getPopupContainer={container ? () => container : undefined}
-      mask
-      maskClosable
-      modalContentClass="codey-settings-modal-content"
-      onCancel={onCancel}
-      visible={visible}
-      width={1040}
-      zIndex={2147483646}
-    >
-      {children}
-    </SemiModal>
-  );
-}
-
 function useStableEvent<Args extends unknown[], Result>(
   callback: (...args: Args) => Result,
 ): (...args: Args) => Result {
@@ -128,19 +85,10 @@ function useStableEvent<Args extends unknown[], Result>(
   useLayoutEffect(() => {
     callbackRef.current = callback;
   }, [callback]);
-  return useCallback(
-    (...args: Args) => callbackRef.current(...args),
-    [],
-  );
+  return useCallback((...args: Args) => callbackRef.current(...args), []);
 }
 
-export function App({
-  embedded = false,
-  modalContainer,
-  modalVisible = true,
-  onAfterClose,
-  onClose,
-}: AppProps) {
+export function App({ embedded = false, onClose }: AppProps) {
   const [config, setConfig] = useState<Config | null>(null);
   const persistedConfigRef = useRef<Config | null>(null);
   const { status, setStatus, refreshStatus, refreshStatusForLoad } =
@@ -165,6 +113,19 @@ export function App({
     null,
   );
   const [traceSnapshotStale, setTraceSnapshotStale] = useState(false);
+
+  // Toast lives in the main shell only; keep loading copy until config arrives.
+  useEffect(() => {
+    if (!config || !notice.text) return;
+    const timeoutMs = notice.tone === "error" ? 7000 : 4000;
+    const token = notice.text;
+    const timer = window.setTimeout(() => {
+      setNotice((current) =>
+        current.text === token ? { tone: "info", text: "" } : current,
+      );
+    }, timeoutMs);
+    return () => window.clearTimeout(timer);
+  }, [config, notice.text, notice.tone]);
 
   const provider = ccSwitchStatus?.provider;
   const isBusy = busy !== null;
@@ -195,12 +156,19 @@ export function App({
     setSubagentOptimization,
   });
   const {
+    webhookResults,
     addNotificationChannel,
     updateNotificationChannel,
     removeNotificationChannel,
+    testWebhook,
   } = useNotifications({
+    config,
+    isBusy,
     setConfig,
     setDirty,
+    setBusy,
+    setNotice,
+    persist,
   });
   const {
     updateResult,
@@ -442,6 +410,17 @@ export function App({
     onClose?.();
   }
 
+  const handleCloseSettings = useStableEvent(closeSettings);
+
+  useEffect(() => {
+    if (!embedded && !onClose) return;
+    const onRequestClose = () => handleCloseSettings();
+    window.addEventListener(SETTINGS_REQUEST_CLOSE_EVENT, onRequestClose);
+    return () => {
+      window.removeEventListener(SETTINGS_REQUEST_CLOSE_EVENT, onRequestClose);
+    };
+  }, [embedded, onClose, handleCloseSettings]);
+
   function askClearTraceLogs() {
     setConfirmation({
       action: "clear",
@@ -461,18 +440,6 @@ export function App({
         "当前 Codex 客户端将被关闭并由 Codey 自动重新拉起，正在执行的本地任务会被中断。",
       confirmLabel: "重启 Codex",
       run: () => void restartCodex(),
-    });
-  }
-
-  function askRemoveNotificationChannel(channel: NotificationChannel) {
-    const channelName = channel.kind === "telegram" ? "Telegram" : "飞书";
-    setConfirmation({
-      action: "delete-notification-channel",
-      title: `删除${channelName}通知渠道？`,
-      description:
-        "将从当前设置中移除这个通知渠道。删除后不会再接收自动通知；如果尚未保存，可关闭设置页面撤销本次更改。",
-      confirmLabel: "删除渠道",
-      run: () => removeNotificationChannel(channel.id),
     });
   }
 
@@ -558,18 +525,13 @@ export function App({
     });
   }
 
-  const handleCloseSettings = useStableEvent(closeSettings);
   const handleSaveCurrent = useStableEvent(() => void saveCurrent());
   const handleRepairPluginMarketplace = useStableEvent(
     () => void repairPluginMarketplace(),
   );
   const handleRestartCodex = useStableEvent(askRestartCodex);
-  const handleCheckForUpdates = useStableEvent(
-    () => void checkForUpdates(),
-  );
-  const handleDownloadUpdate = useStableEvent(
-    () => void downloadUpdate(),
-  );
+  const handleCheckForUpdates = useStableEvent(() => void checkForUpdates());
+  const handleDownloadUpdate = useStableEvent(() => void downloadUpdate());
   const handleInstallDownloadedUpdate = useStableEvent(
     askInstallDownloadedUpdate,
   );
@@ -581,8 +543,11 @@ export function App({
   const handleNotificationChannelChange = useStableEvent(
     updateNotificationChannel,
   );
-  const handleRequestRemoveNotificationChannel = useStableEvent(
-    askRemoveNotificationChannel,
+  const handleRemoveNotificationChannel = useStableEvent(
+    removeNotificationChannel,
+  );
+  const handleTestWebhook = useStableEvent(
+    (channelId: string) => void testWebhook(channelId),
   );
   const handleSubagentOptimizationChange = useStableEvent(
     (checked: boolean) => void updateSubagentOptimization(checked),
@@ -607,9 +572,7 @@ export function App({
   const handleSaveModelSelection = useStableEvent(
     () => void saveModelSelection(),
   );
-  const handleConfirmationClose = useStableEvent(
-    () => setConfirmation(null),
-  );
+  const handleConfirmationClose = useStableEvent(() => setConfirmation(null));
   const handleConfirmationConfirm = useStableEvent((pending: Confirmation) => {
     setConfirmation(null);
     pending.run();
@@ -625,7 +588,7 @@ export function App({
   );
 
   if (!config || !provider) {
-    const loadingContent = (
+    return (
       <main className="app-shell loading-shell">
         <div className="loading-mark">
           <GitBranch size={17} />
@@ -641,72 +604,9 @@ export function App({
         />
       </main>
     );
-    return embedded ? (
-      <SettingsModalShell
-        afterClose={onAfterClose}
-        container={modalContainer}
-        onCancel={handleCloseSettings}
-        title="Codey 配置"
-        visible={modalVisible}
-      >
-        {loadingContent}
-      </SettingsModalShell>
-    ) : loadingContent;
   }
 
-  const configHeaderContent = (
-    <div className="config-header-inner">
-      <div className="config-brand">
-        <CodeyBrandMark />
-        <div className="config-brand-copy">
-          <div className="config-brand-title-row">
-            <h1 id={embedded ? "semi-modal-title" : undefined}>Codey 控制台</h1>
-            <span className="app-version-tag">
-              v{status.appVersion || "0.2.0"}
-            </span>
-            {dirty && (
-              <Badge variant="warning" className="unsaved-badge">
-                未保存更改
-              </Badge>
-            )}
-          </div>
-          <p>管理 Codex 线路、模型服务、运行策略与诊断日志</p>
-        </div>
-      </div>
-
-      <div className="config-header-right">
-        <div className="config-header-actions">
-          <SaveButton
-            className={`save-button${dirty ? " dirty" : ""}`}
-            disabled={!dirty || isBusy}
-            onClick={handleSaveCurrent}
-          >
-            {busy === "save" ? (
-              <LoaderCircle className="spinner" aria-hidden="true" />
-            ) : dirty ? (
-              <Save aria-hidden="true" />
-            ) : (
-              <Check aria-hidden="true" />
-            )}
-            {dirty ? "保存更改" : "已保存"}
-          </SaveButton>
-          {embedded && (
-            <Button
-              aria-label="关闭配置"
-              className="codey-settings-modal-close"
-              onClick={handleCloseSettings}
-              size="icon-sm"
-              variant="ghost"
-            >
-              <X aria-hidden="true" />
-            </Button>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-
-  const appContent = (
+  return (
     <main
       className={`app-shell${embedded ? " embedded" : ""}`}
       ref={setPortalContainer}
@@ -715,38 +615,66 @@ export function App({
         跳至设置内容
       </a>
 
-      {!embedded && (
-        <div className="macos-titlebar">
-          <div className="macos-traffic-lights">
-            <button
-              className="traffic-light close"
-              title="关闭"
-              aria-label="关闭窗口"
-            />
-            <button
-              className="traffic-light minimize"
-              title="最小化"
-              aria-label="最小化窗口"
-            />
-            <button
-              className="traffic-light zoom"
-              title="缩放"
-              aria-label="全屏缩放"
-            />
-          </div>
-          <div className="macos-titlebar-title">
-            <span className="app-title-text">Codey Control Panel</span>
-            <span className="app-version-tag">
-              v{status.appVersion || "0.2.0"}
-            </span>
-          </div>
-          <div className="macos-titlebar-right" aria-hidden="true" />
+      <div className="panel-titlebar">
+        <div className="panel-titlebar-side" aria-hidden="true" />
+        <div className="panel-titlebar-title">
+          <span className="app-title-text">Codey Control Panel</span>
+          <span className="app-version-tag">
+            v{status.appVersion || "0.2.0"}
+          </span>
         </div>
-      )}
+        <div className="panel-titlebar-side panel-titlebar-side-end">
+          {(embedded || onClose) && (
+            <button
+              type="button"
+              className="panel-titlebar-close"
+              data-codey-tip="关闭"
+              onClick={handleCloseSettings}
+              aria-label="关闭"
+            >
+              <X size={16} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      </div>
 
-      {!embedded && (
-        <header className="config-header">{configHeaderContent}</header>
-      )}
+      <header className="config-header">
+        <div className="config-header-inner">
+          <div className="config-brand">
+            <CodeyBrandMark />
+            <div className="config-brand-copy">
+              <div className="config-brand-title-row">
+                <h1>Codey 控制台</h1>
+                {dirty && (
+                  <Badge variant="warning" className="unsaved-badge">
+                    未保存更改
+                  </Badge>
+                )}
+              </div>
+              <p>管理 Codex 线路、模型服务、运行策略与诊断日志</p>
+            </div>
+          </div>
+
+          <div className="config-header-right">
+            <div className="config-header-actions">
+              <SaveButton
+                className={`save-button${dirty ? " dirty" : ""}`}
+                disabled={!dirty || isBusy}
+                onClick={handleSaveCurrent}
+              >
+                {busy === "save" ? (
+                  <LoaderCircle className="spinner" aria-hidden="true" />
+                ) : dirty ? (
+                  <Save aria-hidden="true" />
+                ) : (
+                  <Check aria-hidden="true" />
+                )}
+                {dirty ? "保存更改" : "已保存"}
+              </SaveButton>
+            </div>
+          </div>
+        </div>
+      </header>
 
       <div className="page-scroll">
         <div className="page" id="codey-settings-content">
@@ -791,11 +719,13 @@ export function App({
             <div className="dashboard-column upper-right-column">
               <NotificationChannelsCard
                 config={config}
-                container={portalContainer}
+                busy={busy}
                 isBusy={isBusy}
+                webhookResults={webhookResults}
                 onAddChannel={handleAddNotificationChannel}
                 onChannelChange={handleNotificationChannelChange}
-                onRequestRemoveChannel={handleRequestRemoveNotificationChannel}
+                onRemoveChannel={handleRemoveNotificationChannel}
+                onTestWebhook={handleTestWebhook}
               />
 
               <FeaturePolicyCard
@@ -905,19 +835,4 @@ export function App({
       )}
     </main>
   );
-  return embedded ? (
-    <SettingsModalShell
-      afterClose={onAfterClose}
-      container={modalContainer}
-      header={(
-        <div className="semi-modal-header codey-settings-modal-header">
-          {configHeaderContent}
-        </div>
-      )}
-      onCancel={handleCloseSettings}
-      visible={modalVisible}
-    >
-      {appContent}
-    </SettingsModalShell>
-  ) : appContent;
 }

--- a/src/OperationsPanel.tsx
+++ b/src/OperationsPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useState } from "react";
+import { memo, useState } from "react";
 import {
   IconActivity as Activity,
   IconAdjustmentsHorizontal,
@@ -21,8 +21,12 @@ import {
   IconBolt as Zap,
 } from "@tabler/icons-react";
 
-import type { Config, PluginMarketplaceStatus, RuntimeStatus } from "./App.types";
-import { Badge, Button, Card, Tooltip } from "./components/semi";
+import type {
+  Config,
+  PluginMarketplaceStatus,
+  RuntimeStatus,
+} from "./App.types";
+import { Badge, Button, Card } from "./components/semi";
 
 const Cpu = IconCpu;
 const FolderOpen = IconFolderOpen;
@@ -47,12 +51,7 @@ function OperationsPanelComponent({
   onRepairPluginMarketplace,
   onRestart,
 }: OperationsPanelProps) {
-  const operationsHubRef = useRef<HTMLElement>(null);
   const [activeCardTitle, setActiveCardTitle] = useState<string | null>(null);
-
-  const getTooltipContainer = () =>
-    operationsHubRef.current?.closest<HTMLElement>(".app-shell") ??
-    document.body;
 
   const toggleCard = (title: string) => {
     setActiveCardTitle((prev) => (prev === title ? null : title));
@@ -304,7 +303,6 @@ function OperationsPanelComponent({
 
   return (
     <section
-      ref={operationsHubRef}
       className={`operations-hub${restartPending ? " pending" : status.running ? " running" : ""}`}
       aria-labelledby="operations-title"
     >
@@ -335,31 +333,23 @@ function OperationsPanelComponent({
               {statusCards.map((item) => {
                 const StatusIcon = item.icon;
                 const isExpanded = activeCardTitle === item.title;
+                const tip = isExpanded
+                  ? `收起“${item.title}”`
+                  : `点击展开“${item.title}”详情`;
                 return (
-                  <Tooltip
+                  <button
                     key={item.title}
-                    content={
-                      isExpanded
-                        ? `收起“${item.title}”`
-                        : `点击展开“${item.title}”详情`
-                    }
-                    getPopupContainer={getTooltipContainer}
-                    position="top"
+                    type="button"
+                    role="listitem"
+                    className={`operations-icon-badge tone-${item.tone}${isExpanded ? " active" : ""}`}
+                    data-codey-tip={tip}
+                    onClick={() => toggleCard(item.title)}
+                    aria-expanded={isExpanded}
+                    aria-label={`${item.title}（${item.label}），点击${isExpanded ? "收起" : "展开"}`}
                   >
-                    <button
-                      type="button"
-                      className={`operations-icon-badge tone-${item.tone}${isExpanded ? " active" : ""}`}
-                      onClick={() => toggleCard(item.title)}
-                      aria-expanded={isExpanded}
-                      aria-label={`${item.title}（${item.label}），点击${isExpanded ? "收起" : "展开"}`}
-                    >
-                      <StatusIcon size={16} aria-hidden="true" />
-                      <span
-                        className="operations-icon-dot"
-                        aria-hidden="true"
-                      />
-                    </button>
-                  </Tooltip>
+                    <StatusIcon size={16} aria-hidden="true" />
+                    <span className="operations-icon-dot" aria-hidden="true" />
+                  </button>
                 );
               })}
             </div>

--- a/src/overlay.css
+++ b/src/overlay.css
@@ -1,102 +1,106 @@
+/* Full-viewport host + mask. Dialog uses uniform 36px inset on all sides. */
 :host {
   all: initial;
-  color-scheme: light;
+  color-scheme: dark;
+  box-sizing: border-box;
+  display: none;
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  z-index: 2147483647;
+  pointer-events: none;
+  opacity: 0;
+  -webkit-app-region: no-drag !important;
+  --codey-overlay-inset: 36px;
+  --codey-overlay-motion: 200ms;
 }
 
-#codey-overlay-root,
-#codey-overlay-modal-container {
+:host([data-open]),
+:host([data-closing]) {
+  display: block;
+}
+
+:host([data-open]) {
+  pointer-events: auto;
+  opacity: 1;
+  transition: opacity var(--codey-overlay-motion) ease;
+}
+
+:host([data-closing]) {
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--codey-overlay-motion) ease;
+}
+
+.codey-overlay-backdrop {
+  -webkit-app-region: no-drag !important;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-sizing: border-box;
+  display: grid;
   inset: 0;
-  position: fixed;
+  justify-items: center;
+  align-items: stretch;
+  padding: var(--codey-overlay-inset);
+  pointer-events: auto;
+  position: absolute;
   width: 100%;
+  height: 100%;
+  z-index: 1;
+  cursor: default;
+}
+
+.codey-overlay-dialog {
+  -webkit-app-region: no-drag !important;
+  background: #0b1120;
+  border: 1px solid rgba(71, 85, 105, 0.68);
+  border-radius: 16px;
+  box-shadow: 0 30px 100px rgba(0, 0, 0, 0.48);
+  box-sizing: border-box;
+  height: 100%;
+  max-height: 100%;
+  max-width: 1040px;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+  width: min(1040px, 100%);
+  pointer-events: auto;
+  z-index: 2;
+  opacity: 0.96;
+  transform: translateY(12px) scale(0.98);
+  transition:
+    transform var(--codey-overlay-motion) ease,
+    opacity var(--codey-overlay-motion) ease;
+}
+
+:host([data-open]) .codey-overlay-dialog {
+  opacity: 1;
+  transform: none;
+}
+
+:host([data-closing]) .codey-overlay-dialog {
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
 }
 
 #codey-overlay-root {
-  pointer-events: none;
-}
-
-.codey-settings-modal-layer {
-  -webkit-app-region: no-drag !important;
-}
-
-.codey-settings-modal-layer .semi-modal-wrap {
-  padding: 22px;
-}
-
-.codey-settings-modal-layer .semi-modal {
-  height: min(820px, calc(100vh - 40px));
-  max-width: calc(100vw - 40px);
-}
-
-.codey-settings-modal-content {
   height: 100%;
-  overflow: hidden;
-  padding: 0;
-}
-
-.codey-settings-modal-content .semi-modal-header {
-  flex: 0 0 auto;
-  margin: 0;
-  border-bottom: 1px solid var(--semi-color-border);
-  padding: 18px 24px;
-}
-
-.codey-settings-modal-content .semi-modal-body {
-  min-height: 0;
-  flex: 1 1 auto;
-  overflow: hidden;
-  margin: 0;
-  padding: 0;
-}
-
-.codey-settings-modal-header {
-  align-items: center;
-}
-
-.codey-settings-modal-header .config-header-inner {
   width: 100%;
-  min-width: 0;
-}
-
-.codey-settings-modal-close {
-  flex: 0 0 auto;
+  min-height: 0;
 }
 
 @media (max-width: 760px) {
-  .codey-settings-modal-layer .semi-modal-wrap {
-    padding: 8px;
+  :host {
+    --codey-overlay-inset: 36px;
   }
 
-  .codey-settings-modal-layer .semi-modal {
-    height: calc(100vh - 16px);
-    max-width: calc(100vw - 16px);
-  }
-
-  .codey-settings-modal-content .codey-settings-modal-header {
-    padding: 12px 14px;
-  }
-
-  .codey-settings-modal-header .config-header-inner {
-    flex-direction: row;
-    align-items: center;
-    gap: 10px;
-  }
-
-  .codey-settings-modal-header .config-brand {
-    min-width: 0;
-    gap: 8px;
-  }
-
-  .codey-settings-modal-header .config-brand-mark {
-    width: 32px;
-    height: 32px;
-  }
-
-  .codey-settings-modal-header .config-brand-copy p {
-    display: none;
-  }
-
-  .codey-settings-modal-header .config-header-right {
-    width: auto;
-    flex-direction: row;
+  .codey-overlay-dialog {
+    border-radius: 12px;
   }
 }

--- a/src/overlay.tsx
+++ b/src/overlay.tsx
@@ -6,6 +6,26 @@ import overlayStyles from "./overlay.css?inline";
 import { codeyApiPath } from "./api";
 
 const SETTINGS_OPENED_EVENT = "codey-settings-opened";
+/** App listens and runs closeSettings() so unsaved edits are discarded cleanly. */
+const SETTINGS_REQUEST_CLOSE_EVENT = "codey-settings-request-close";
+const OVERLAY_MOTION_MS = 200;
+const PAGE_LOCK_CLASS = "codey-settings-overlay-open";
+const PAGE_LOCK_STYLE_ID = "codey-settings-overlay-page-lock";
+const PAGE_LOCK_EVENTS = [
+  "pointerdown",
+  "pointerup",
+  "pointermove",
+  "mousedown",
+  "mouseup",
+  "click",
+  "auxclick",
+  "contextmenu",
+  "touchstart",
+  "touchmove",
+  "touchend",
+  "wheel",
+  "keydown",
+] as const;
 
 type OverlayController = {
   open: () => void;
@@ -37,57 +57,217 @@ if (!window.__codeySettingsOverlay) {
   delete window.__codeyComponentStyles;
   const host = document.createElement("div");
   host.id = "codey-settings-overlay-host";
-  host.style.display = "none";
   host.setAttribute("aria-hidden", "true");
+  // Full-viewport hit + paint target. Dialog inset is CSS-only.
+  Object.assign(host.style, {
+    position: "fixed",
+    inset: "0px",
+    width: "100%",
+    height: "100%",
+    margin: "0px",
+    padding: "0px",
+    border: "0px",
+    zIndex: "2147483647",
+    display: "none",
+    pointerEvents: "none",
+  });
+  host.style.setProperty("-webkit-app-region", "no-drag");
+
   const shadow = host.attachShadow({ mode: "open" });
   const style = document.createElement("style");
   style.textContent = `${componentStyles}\n${overlayStyles}\n${appStyles}`;
+  const backdrop = document.createElement("div");
+  backdrop.className = "codey-overlay-backdrop";
+  backdrop.setAttribute("data-codey-overlay-mask", "true");
+  const dialog = document.createElement("section");
+  dialog.className = "codey-overlay-dialog";
+  dialog.setAttribute("role", "dialog");
+  dialog.setAttribute("aria-modal", "true");
+  dialog.setAttribute("aria-label", "Codey 配置");
+  dialog.tabIndex = -1;
   const rootElement = document.createElement("div");
   rootElement.id = "codey-overlay-root";
-  const modalContainer = document.createElement("div");
-  modalContainer.id = "codey-overlay-modal-container";
-  shadow.append(style, rootElement, modalContainer);
+  dialog.appendChild(rootElement);
+  backdrop.appendChild(dialog);
+  shadow.append(style, backdrop);
   document.documentElement.appendChild(host);
 
-  let hideTimer: number | undefined;
-  const hide = () => {
-    window.clearTimeout(hideTimer);
-    hideTimer = undefined;
-    host.style.display = "none";
-    host.setAttribute("aria-hidden", "true");
-  };
-  const reactRoot = ReactDOM.createRoot(rootElement);
-  const render = (visible: boolean) => {
-    reactRoot.render(
-      <App
-        embedded
-        modalContainer={modalContainer}
-        modalVisible={visible}
-        onAfterClose={hide}
-        onClose={close}
-      />,
-    );
-  };
-  const close = () => {
-    render(false);
-    window.clearTimeout(hideTimer);
-    hideTimer = window.setTimeout(hide, 250);
-  };
-  const open = () => {
-    window.clearTimeout(hideTimer);
-    hideTimer = undefined;
-    host.style.display = "block";
-    host.setAttribute("aria-hidden", "false");
-    render(true);
-    window.dispatchEvent(new CustomEvent(SETTINGS_OPENED_EVENT));
-  };
-  const isOpen = () => host.style.display !== "none";
+  let closeTimer = 0;
+  let pageLocked = false;
 
-  render(false);
+  const ensurePageLockStyle = () => {
+    if (document.getElementById(PAGE_LOCK_STYLE_ID)) return;
+    const lockStyle = document.createElement("style");
+    lockStyle.id = PAGE_LOCK_STYLE_ID;
+    // body is Codex UI; host is a sibling under <html>, so this freezes the page
+    // without disabling the overlay itself.
+    lockStyle.textContent = `
+      html.${PAGE_LOCK_CLASS},
+      html.${PAGE_LOCK_CLASS} body {
+        pointer-events: none !important;
+      }
+      html.${PAGE_LOCK_CLASS} #codey-settings-overlay-host,
+      html.${PAGE_LOCK_CLASS} #codey-settings-button {
+        pointer-events: auto !important;
+      }
+    `;
+    document.documentElement.appendChild(lockStyle);
+  };
+
+  const eventBelongsToOverlay = (event: Event) => {
+    const path =
+      typeof event.composedPath === "function" ? event.composedPath() : [];
+    if (path.includes(host)) return true;
+    const target = event.target;
+    if (target === host) return true;
+    if (target instanceof Element) {
+      if (target.id === "codey-settings-button") return true;
+      if (target.closest?.("#codey-settings-button")) return true;
+    }
+    return false;
+  };
+
+  const lockPageInteraction = (event: Event) => {
+    if (
+      !host.hasAttribute("data-open") &&
+      !host.hasAttribute("data-closing")
+    ) {
+      return;
+    }
+    if (eventBelongsToOverlay(event)) return;
+    // Esc closes settings; other keys must not reach Codex shortcuts.
+    if (event.type === "keydown") {
+      const keyEvent = event as KeyboardEvent;
+      if (keyEvent.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (host.hasAttribute("data-open")) requestClose();
+        return;
+      }
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+  };
+
+  const lockPage = () => {
+    if (pageLocked) return;
+    pageLocked = true;
+    ensurePageLockStyle();
+    document.documentElement.classList.add(PAGE_LOCK_CLASS);
+    try {
+      document.body?.setAttribute("inert", "");
+    } catch {
+      // Older Chromium may lack inert; pointer-events CSS still applies.
+    }
+    for (const type of PAGE_LOCK_EVENTS) {
+      window.addEventListener(type, lockPageInteraction, true);
+    }
+  };
+
+  const unlockPage = () => {
+    if (!pageLocked) return;
+    pageLocked = false;
+    document.documentElement.classList.remove(PAGE_LOCK_CLASS);
+    try {
+      document.body?.removeAttribute("inert");
+    } catch {
+      // ignore
+    }
+    for (const type of PAGE_LOCK_EVENTS) {
+      window.removeEventListener(type, lockPageInteraction, true);
+    }
+  };
+
+  const isOpen = () =>
+    host.hasAttribute("data-open") || host.hasAttribute("data-closing");
+
+  const finishClose = () => {
+    if (closeTimer) {
+      window.clearTimeout(closeTimer);
+      closeTimer = 0;
+    }
+    host.removeAttribute("data-open");
+    host.removeAttribute("data-closing");
+    host.style.display = "none";
+    host.style.pointerEvents = "none";
+    host.setAttribute("aria-hidden", "true");
+    unlockPage();
+  };
+
+  const close = () => {
+    if (!isOpen()) return;
+    if (host.hasAttribute("data-closing")) return;
+
+    host.removeAttribute("data-open");
+    host.setAttribute("data-closing", "");
+    host.style.pointerEvents = "none";
+    host.setAttribute("aria-hidden", "true");
+    // Keep page locked through the exit motion so Codex cannot steal the click.
+    lockPage();
+
+    const onTransitionEnd = (event: TransitionEvent) => {
+      if (event.target !== host && event.target !== dialog) return;
+      host.removeEventListener("transitionend", onTransitionEnd);
+      finishClose();
+    };
+    host.addEventListener("transitionend", onTransitionEnd);
+    closeTimer = window.setTimeout(finishClose, OVERLAY_MOTION_MS + 80);
+  };
+
+  const open = () => {
+    if (host.hasAttribute("data-open")) return;
+    if (closeTimer) {
+      window.clearTimeout(closeTimer);
+      closeTimer = 0;
+    }
+    host.removeAttribute("data-closing");
+    host.style.display = "block";
+    host.style.pointerEvents = "auto";
+    host.style.inset = "0px";
+    host.style.width = "100%";
+    host.style.height = "100%";
+    host.setAttribute("aria-hidden", "false");
+    lockPage();
+    // Two frames so display:block applies before opacity/transform transitions.
+    requestAnimationFrame(() => {
+      host.setAttribute("data-open", "");
+      window.dispatchEvent(new CustomEvent(SETTINGS_OPENED_EVENT));
+      requestAnimationFrame(() => dialog.focus({ preventScroll: true }));
+    });
+  };
+
+  const requestClose = () => {
+    // Prefer App.closeSettings so dirty form state is restored first.
+    window.dispatchEvent(new CustomEvent(SETTINGS_REQUEST_CLOSE_EVENT));
+    // Fallback if the React tree has not attached a listener yet.
+    queueMicrotask(() => {
+      if (host.hasAttribute("data-open") && !host.hasAttribute("data-closing")) {
+        close();
+      }
+    });
+  };
+
+  // Mask click closes. Clicks inside the dialog must not bubble to the mask.
+  backdrop.addEventListener("click", (event) => {
+    if (event.target === backdrop) {
+      event.preventDefault();
+      event.stopPropagation();
+      requestClose();
+    }
+  });
+  dialog.addEventListener("click", (event) => {
+    event.stopPropagation();
+  });
+
+  ReactDOM.createRoot(rootElement).render(<App embedded onClose={close} />);
   window.__codeySettingsOverlay = {
     open,
     close,
     isOpen,
-    toggle: open,
+    toggle: () => {
+      if (host.hasAttribute("data-open")) requestClose();
+      else if (!host.hasAttribute("data-closing")) open();
+    },
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -89,6 +89,53 @@ input:focus-visible,
   isolation: isolate;
 }
 
+/* Anchored tips inside the overlay (avoids Semi portal offset in Shadow DOM). */
+[data-codey-tip] {
+  position: relative;
+}
+
+[data-codey-tip]::after {
+  content: attr(data-codey-tip);
+  position: absolute;
+  z-index: 80;
+  top: calc(100% + 8px);
+  left: 50%;
+  width: max-content;
+  max-width: min(280px, 70vw);
+  padding: 5px 9px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: rgba(29, 29, 31, 0.94);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: 0;
+  text-align: center;
+  white-space: nowrap;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(-2px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+[data-codey-tip]:hover::after,
+[data-codey-tip]:focus-visible::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Titlebar tips open downward so they stay inside the panel. */
+.panel-titlebar [data-codey-tip]::after {
+  top: calc(100% + 10px);
+}
+
+/* Status icons also open downward; keep clear of the hover lift. */
+.operations-icon-badge[data-codey-tip]::after {
+  top: calc(100% + 10px);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -125,16 +172,17 @@ input:focus-visible,
 }
 
 /* ==========================================================================
-   macOS Window Titlebar & Header
+   Panel Titlebar & Header
    ========================================================================== */
 
-.macos-titlebar {
+.panel-titlebar {
   display: flex;
   height: 38px;
   flex: 0 0 38px;
   align-items: center;
   justify-content: space-between;
-  padding: 0 16px;
+  gap: 12px;
+  padding: 0 12px 0 16px;
   background: rgba(246, 246, 248, 0.85);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
@@ -143,42 +191,23 @@ input:focus-visible,
   z-index: 40;
 }
 
-.macos-traffic-lights {
+.panel-titlebar-side {
   display: flex;
+  width: 40px;
+  flex: 0 0 40px;
   align-items: center;
-  gap: 8px;
-  width: 140px;
 }
 
-.traffic-light {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  padding: 0;
-  cursor: pointer;
-  transition: opacity 120ms ease;
+.panel-titlebar-side-end {
+  justify-content: flex-end;
 }
 
-.traffic-light:hover {
-  opacity: 0.85;
-}
-
-.traffic-light.close {
-  background: #ff5f56;
-}
-
-.traffic-light.minimize {
-  background: #ffbd2e;
-}
-
-.traffic-light.zoom {
-  background: #27c93f;
-}
-
-.macos-titlebar-title {
+.panel-titlebar-title {
   display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   font-size: 12px;
   font-weight: 600;
@@ -199,11 +228,35 @@ input:focus-visible,
   border-radius: 999px;
 }
 
-.macos-titlebar-right {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  width: 140px;
+.panel-titlebar-close {
+  display: inline-grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  border: 0;
+  border-radius: 8px;
+  padding: 0;
+  background: transparent;
+  color: #6e6e73;
+  cursor: pointer;
+  appearance: none;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.panel-titlebar-close:hover {
+  background: rgba(255, 59, 48, 0.12);
+  color: #d70015;
+}
+
+.panel-titlebar-close:focus-visible {
+  outline: 2px solid rgba(0, 122, 255, 0.72);
+  outline-offset: 1px;
+}
+
+.panel-titlebar-close:active {
+  background: rgba(255, 59, 48, 0.18);
 }
 
 .config-header {
@@ -371,15 +424,16 @@ input:focus-visible,
   background: var(--mac-card-bg);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.02);
   transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.route-card,
+.secondary-card,
+.trace-card {
   overflow: hidden;
 }
 
-.operations-panel:hover,
-.route-card:hover,
-.secondary-card:hover,
-.trace-card:hover {
-  border-color: rgba(0, 0, 0, 0.12);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+.operations-panel {
+  overflow: visible;
 }
 
 .operations-header {
@@ -390,6 +444,27 @@ input:focus-visible,
   padding: 18px 22px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
   background: linear-gradient(180deg, #ffffff 0%, #fafafa 100%);
+  overflow: visible;
+}
+
+.operations-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  overflow: visible;
+}
+
+.operations-status-icons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  padding-right: 12px;
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
+  margin-right: 4px;
+  flex-shrink: 0;
+  flex-wrap: nowrap;
+  overflow: visible;
 }
 
 .operations-heading {
@@ -420,12 +495,6 @@ input:focus-visible,
   margin: 0;
   font-size: 12px;
   color: #6e6e73;
-}
-
-.operations-actions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
 }
 
 .windows-patch-status {
@@ -505,18 +574,6 @@ input:focus-visible,
   display: flex;
   align-items: center;
   gap: 6px;
-}
-
-.operations-status-icons {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 8px;
-  padding-right: 12px;
-  border-right: 1px solid rgba(0, 0, 0, 0.08);
-  margin-right: 4px;
-  flex-shrink: 0;
-  flex-wrap: nowrap;
 }
 
 .operations-icon-badge.active {
@@ -820,11 +877,10 @@ input:focus-visible,
   color: #3a3a3c;
   cursor: pointer;
   padding: 0;
-  transition: all 160ms ease;
+  transition: box-shadow 160ms ease, border-color 160ms ease, background 160ms ease;
 }
 
 .operations-icon-badge:hover {
-  transform: translateY(-1px);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
@@ -1479,12 +1535,13 @@ input:focus-visible,
   cursor: not-allowed;
 }
 
-.gpu-mode-card-body > small {
+.gpu-mode-card-body>small {
   display: block;
   margin-top: 8px;
 }
 
 @media (prefers-reduced-motion: reduce) {
+
   .gpu-mode-slider,
   .gpu-mode-slider-thumb,
   .gpu-mode-option {
@@ -1502,13 +1559,6 @@ input:focus-visible,
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.notification-channel-list > li {
-  min-width: 0;
 }
 
 .notification-add-actions,
@@ -1517,8 +1567,6 @@ input:focus-visible,
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
-  flex-wrap: wrap;
-  justify-content: flex-end;
 }
 
 .notification-add-actions {
@@ -1530,11 +1578,6 @@ input:focus-visible,
   border-color: rgba(0, 122, 255, 0.2);
 }
 
-.notification-card.inactive {
-  border-color: rgba(0, 0, 0, 0.08);
-  background: #fbfbfc;
-}
-
 .notification-card-header {
   display: flex;
   align-items: center;
@@ -1542,8 +1585,11 @@ input:focus-visible,
   gap: 12px;
 }
 
-.notification-edit-button {
-  color: #4d4d52;
+.notification-channel-controls>span {
+  color: #6e6e73;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .notification-remove-button {
@@ -1580,7 +1626,7 @@ input:focus-visible,
   gap: 12px;
 }
 
-.notification-title > div {
+.notification-title>div {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -1635,190 +1681,6 @@ input:focus-visible,
   color: #6e6e73;
 }
 
-.notification-dialog-channel {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 20px;
-}
-
-.notification-dialog-fields {
-  margin-top: 18px;
-}
-
-.notification-dialog-actions {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.15fr);
-  margin-top: 16px;
-  overflow: hidden;
-  border: 1px solid rgba(0, 0, 0, 0.09);
-  border-radius: 10px;
-  background: #fafbfc;
-}
-
-.notification-enabled-control {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 12px;
-  min-height: 68px;
-  padding: 12px 14px;
-}
-
-.notification-enabled-control > div {
-  display: grid;
-  gap: 2px;
-}
-
-.notification-enabled-control strong {
-  color: #3a3a3c;
-  font-size: 12px;
-}
-
-.notification-enabled-control small {
-  color: #6e6e73;
-  font-size: 11px;
-  line-height: 1.4;
-}
-
-.notification-dialog-test {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 12px;
-  min-height: 68px;
-  border-left: 1px solid rgba(0, 0, 0, 0.08);
-  padding: 12px 14px;
-}
-
-.notification-dialog-test > div {
-  display: grid;
-  min-width: 0;
-  gap: 3px;
-}
-
-.notification-dialog-test strong {
-  color: #3a3a3c;
-  font-size: 12px;
-}
-
-.notification-dialog-test small {
-  color: #6e6e73;
-  font-size: 11px;
-  line-height: 1.4;
-}
-
-.notification-dialog-test .inline-result {
-  overflow: hidden;
-  min-height: 15px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.notification-dialog-test .codey-button {
-  flex-shrink: 0;
-}
-
-.notification-test-error {
-  margin: 8px 0 0;
-  color: #d70015;
-  font-size: 11px;
-  line-height: 1.45;
-}
-
-.notification-reveal-loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 100px;
-  margin-top: 16px;
-  border: 1px dashed rgba(0, 0, 0, 0.14);
-  border-radius: 10px;
-  color: #6e6e73;
-  font-size: 12px;
-}
-
-.notification-reveal-error {
-  margin: 12px 0 0;
-  color: #d70015;
-  font-size: 11px;
-  line-height: 1.5;
-}
-
-.notification-channel-picker {
-  display: grid;
-  gap: 8px;
-  margin-top: 20px;
-}
-
-.notification-channel-picker-item {
-  display: block !important;
-  width: 100%;
-  min-height: 72px;
-  height: auto !important;
-  padding: 0 !important;
-  border-color: rgba(0, 0, 0, 0.1) !important;
-  background: #fbfbfc !important;
-  color: #1d1d1f !important;
-  text-align: left;
-}
-
-.notification-channel-picker-item:hover:not(:disabled) {
-  border-color: rgba(0, 122, 255, 0.35) !important;
-  background: #f4f8ff !important;
-}
-
-.notification-channel-picker-item .semi-button-content {
-  display: grid;
-  grid-template-columns: 36px minmax(0, 1fr) 16px;
-  width: 100%;
-  min-width: 0;
-  align-items: center;
-  gap: 12px;
-  padding: 12px;
-}
-
-.notification-channel-picker-item .semi-button-content > span:first-child {
-  display: grid;
-  width: 36px;
-  height: 36px;
-  place-items: center;
-  border-radius: 9px;
-  background: rgba(0, 122, 255, 0.1);
-  color: var(--mac-blue);
-}
-
-.notification-channel-picker-item .semi-button-content > span.telegram {
-  background: rgba(34, 158, 217, 0.12);
-  color: #229ed9;
-}
-
-.notification-channel-picker-copy {
-  display: grid;
-  min-width: 0;
-  gap: 2px;
-}
-
-.notification-channel-picker-copy strong {
-  font-size: 13px;
-  font-weight: 650;
-}
-
-.notification-channel-picker-copy small {
-  overflow: hidden;
-  color: #6e6e73;
-  font-size: 11px;
-  line-height: 1.35;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.notification-channel-picker-item .semi-button-content > svg {
-  color: #8e8e93;
-}
-
 .notification-secret-action {
   display: flex;
   justify-content: flex-end;
@@ -1831,6 +1693,15 @@ input:focus-visible,
 
 .notification-secret-action .codey-button:hover {
   color: var(--mac-red);
+}
+
+.notification-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
 }
 
 .inline-result {
@@ -2052,7 +1923,7 @@ input:focus-visible,
   margin-bottom: 4px;
 }
 
-.trace-wear-heading > strong {
+.trace-wear-heading>strong {
   color: #1d1d1f;
   font-size: 12px;
   font-weight: 600;
@@ -2394,8 +2265,15 @@ input:focus-visible,
 }
 
 @keyframes pulse-shimmer {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 0.8; }
+
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+
+  50% {
+    opacity: 0.8;
+  }
 }
 
 /* ==========================================================================
@@ -2608,7 +2486,7 @@ input:focus-visible,
   max-width: 310px;
 }
 
-.model-picker-toolbar > div:last-child {
+.model-picker-toolbar>div:last-child {
   display: flex;
   align-items: center;
   gap: 2px;
@@ -2643,13 +2521,16 @@ input:focus-visible,
 }
 
 .notice-toast {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
+  /* Stay inside .app-shell (position: relative), not the Codex viewport.
+   * fixed + outer overlay inset made the toast hang outside the dialog. */
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
   z-index: 90;
   display: flex;
   align-items: center;
   gap: 10px;
+  max-width: min(360px, calc(100% - 32px));
   padding: 12px 16px;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.92);
@@ -2659,6 +2540,15 @@ input:focus-visible,
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.14);
   font-size: 12px;
   color: #1d1d1f;
+  box-sizing: border-box;
+  pointer-events: auto;
+}
+
+.notice-toast > span {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow-wrap: anywhere;
+  line-height: 1.4;
 }
 
 .notice-toast.success {
@@ -2678,8 +2568,13 @@ input:focus-visible,
 }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ==========================================================================
@@ -2687,6 +2582,7 @@ input:focus-visible,
    ========================================================================== */
 
 @media (max-width: 900px) {
+
   .upper-dashboard-grid,
   .provider-summary,
   .trace-detail-grid {
@@ -2723,7 +2619,7 @@ input:focus-visible,
     min-width: 0;
   }
 
-  .operations-heading > div {
+  .operations-heading>div {
     min-width: 0;
   }
 
@@ -2757,15 +2653,6 @@ input:focus-visible,
 
   .notification-channel-controls {
     justify-content: flex-end;
-  }
-
-  .notification-dialog-actions {
-    grid-template-columns: 1fr;
-  }
-
-  .notification-dialog-test {
-    border-top: 1px solid rgba(0, 0, 0, 0.08);
-    border-left: 0;
   }
 
   .trace-module-actions {

--- a/tests/notice-toast.test.mjs
+++ b/tests/notice-toast.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const root = new URL("../", import.meta.url);
+
+test("notice toast stays inside the app shell and auto-dismisses", async () => {
+  const [appSource, stylesSource] = await Promise.all([
+    readFile(new URL("src/App.tsx", root), "utf8"),
+    readFile(new URL("src/styles.css", root), "utf8"),
+  ]);
+
+  assert.match(stylesSource, /\.notice-toast\s*\{[\s\S]*?position:\s*absolute;/);
+  assert.match(stylesSource, /max-width:\s*min\(360px,\s*calc\(100% - 32px\)\)/);
+  assert.doesNotMatch(
+    stylesSource,
+    /\.notice-toast\s*\{[\s\S]*?position:\s*fixed;/,
+  );
+
+  assert.match(
+    appSource,
+    /useEffect\(\(\) => \{[\s\S]*if \(!config \|\| !notice\.text\) return;/,
+  );
+  assert.match(appSource, /timeoutMs = notice\.tone === "error" \? 7000 : 4000/);
+  assert.match(appSource, /window\.setTimeout\(/);
+  assert.match(
+    appSource,
+    /current\.text === token \? \{ tone: "info", text: "" \} : current/,
+  );
+});

--- a/tests/settings-overlay-dismissal.test.mjs
+++ b/tests/settings-overlay-dismissal.test.mjs
@@ -4,10 +4,11 @@ import test from "node:test";
 
 const root = new URL("../", import.meta.url);
 
-test("settings Semi modal dismissal restores unsaved config", async () => {
-  const [appSource, overlaySource] = await Promise.all([
+test("settings overlay covers the page and closes from the mask", async () => {
+  const [appSource, overlaySource, overlayCss] = await Promise.all([
     readFile(new URL("src/App.tsx", root), "utf8"),
     readFile(new URL("src/overlay.tsx", root), "utf8"),
+    readFile(new URL("src/overlay.css", root), "utf8"),
   ]);
 
   assert.match(
@@ -20,45 +21,65 @@ test("settings Semi modal dismissal restores unsaved config", async () => {
   );
   assert.match(
     appSource,
-    /import SemiModal from "@douyinfe\/semi-ui\/lib\/es\/modal"/,
+    /className="panel-titlebar-close"/,
   );
+  assert.match(appSource, /onClick=\{handleCloseSettings\}/);
+  assert.doesNotMatch(appSource, /traffic-light/);
+  assert.doesNotMatch(appSource, /macos-titlebar/);
+  assert.match(appSource, /codey-settings-request-close/);
   assert.match(
     appSource,
-    /<SemiModal[\s\S]*closeOnEsc[\s\S]*closable[\s\S]*maskClosable[\s\S]*onCancel=\{onCancel\}/,
+    /window\.addEventListener\(SETTINGS_REQUEST_CLOSE_EVENT/,
   );
-  assert.match(appSource, /onCancel=\{handleCloseSettings\}/);
-  assert.match(
-    appSource,
-    /header=\{\([\s\S]*codey-settings-modal-header[\s\S]*configHeaderContent/,
-  );
-  assert.match(appSource, /aria-label="关闭配置"/);
-  assert.match(
-    appSource,
-    /\{!embedded && \(\s*<header className="config-header">\{configHeaderContent\}<\/header>/,
-  );
-  assert.match(appSource, /\{!embedded && \(/);
+  assert.doesNotMatch(appSource, /aria-label="关闭设置"/);
 
-  assert.doesNotMatch(overlaySource, /codey-overlay-backdrop/);
-  assert.doesNotMatch(overlaySource, /codey-overlay-dialog/);
-  assert.match(overlaySource, /modalVisible=\{visible\}/);
-  assert.match(overlaySource, /onClose=\{close\}/);
+  // Full-viewport mask with uniform 36px dialog inset.
+  assert.match(overlayCss, /:host\(\[data-open\]\)/);
+  assert.match(overlayCss, /:host\(\[data-closing\]\)/);
+  assert.match(overlayCss, /pointer-events:\s*auto/);
+  assert.match(overlayCss, /inset:\s*0/);
+  assert.match(overlayCss, /--codey-overlay-inset:\s*36px/);
+  assert.match(overlayCss, /padding:\s*var\(--codey-overlay-inset\)/);
+  assert.match(overlayCss, /display:\s*grid/);
+  assert.match(overlayCss, /height:\s*100%/);
+  assert.match(overlayCss, /--codey-overlay-motion:\s*200ms/);
+  assert.match(overlayCss, /transition:\s*opacity var\(--codey-overlay-motion\)/);
+  assert.match(overlaySource, /inset:\s*"0px"/);
+
+  // Freeze Codex page input while open (menu bar is usually under body).
+  assert.match(overlaySource, /codey-settings-overlay-open/);
+  assert.match(overlaySource, /setAttribute\("inert"/);
+  assert.match(overlaySource, /lockPageInteraction/);
+  assert.match(overlaySource, /addEventListener\(type, lockPageInteraction, true\)/);
+  assert.match(overlaySource, /data-closing/);
+  assert.match(overlaySource, /OVERLAY_MOTION_MS/);
+  assert.match(overlaySource, /transitionend/);
+
   assert.match(overlaySource, /codey-settings-opened/);
-  assert.match(overlaySource, /toggle: open/);
+  assert.match(overlaySource, /codey-settings-request-close/);
+  assert.match(overlaySource, /backdrop\.addEventListener\("click"/);
+  assert.match(overlaySource, /event\.target === backdrop/);
+  assert.match(overlaySource, /host\.setAttribute\("data-open"/);
+  assert.match(overlaySource, /position:\s*"fixed"/);
+  assert.match(overlaySource, /zIndex:\s*"2147483647"/);
+  // Toggle closes an already-open panel instead of only opening.
+  assert.match(
+    overlaySource,
+    /toggle:\s*\(\)\s*=>\s*\{[\s\S]*if \(host\.hasAttribute\("data-open"\)\) requestClose\(\)/,
+  );
 });
 
 test("operations tooltips stay inside the settings overlay", async () => {
-  const appSectionsSource = await readFile(
-    new URL("src/OperationsPanel.tsx", root),
-    "utf8",
-  );
+  const [panelSource, stylesSource] = await Promise.all([
+    readFile(new URL("src/OperationsPanel.tsx", root), "utf8"),
+    readFile(new URL("src/styles.css", root), "utf8"),
+  ]);
+  // CSS ::after tips avoid Semi Tooltip portals escaping the Shadow DOM.
+  assert.match(panelSource, /data-codey-tip=\{tip\}/);
+  assert.match(stylesSource, /\[data-codey-tip\]::after/);
+  assert.match(stylesSource, /pointer-events:\s*none/);
   assert.match(
-    appSectionsSource,
-    /const operationsHubRef = useRef<HTMLElement>\(null\)/,
+    stylesSource,
+    /\.operations-icon-badge\[data-codey-tip\]::after/,
   );
-  assert.match(
-    appSectionsSource,
-    /operationsHubRef\.current\?\s*\.closest<HTMLElement>\("\.app-shell"\)\s*\?\?\s*document\.body/,
-  );
-  assert.match(appSectionsSource, /ref=\{operationsHubRef\}/);
-  assert.match(appSectionsSource, /getPopupContainer=\{getTooltipContainer\}/);
 });


### PR DESCRIPTION
## Summary
- Full-viewport overlay host/mask, lock page input while settings are open.
- Close animation, dialog inset, toast inside app shell, titlebar chrome cleanup.

## Notes
- Local history is unrelated to `origin/main`; this ports the feature files onto upstream.
- Overlay/UI files may need maintainer reconciliation with current Semi modal work on main.

## Test plan
- [ ] Open/close settings: mask blocks page, close animates, backdrop reverts unsaved
- [ ] Notice toast stays inside shell and auto-dismisses