### PR TITLE
feat: mount Codey settings button beside window controls

### DIFF
--- a/public/renderer-inject.js
+++ b/public/renderer-inject.js
@@ -19,8 +19,8 @@
     "[data-app-action-sidebar-project-row]",
     "[data-app-action-sidebar-thread-id][data-app-action-sidebar-thread-title]",
   ].join(", ");
-  const headerSelector = "header, nav";
-  const bootstrapProbeSelector = `${headerSelector}, ${sidebarSelector}`;
+  /** Typical Windows caption cluster (min / max / close). */
+  const windowControlsReservePx = 138;
   const settingsIcon = `
     <svg viewBox="0 0 350 350" aria-hidden="true" focusable="false">
       <rect x="0" y="0" width="350" height="350" rx="34" fill="#fff" stroke="none"></rect>
@@ -38,7 +38,6 @@
   let updateCheckInFlight = false;
   let sessionToolsInteractionArmed = false;
   let bootstrapObserver = null;
-  let headerMountDirty = true;
 
   const queryWithin = (root, selector) => {
     const matches = [];
@@ -62,17 +61,41 @@
     if (document.getElementById(styleId)) return;
     const style = document.createElement("style");
     style.id = styleId;
+    // Sit just left of the window min/max/close cluster (titlebar overlay or
+    // a Windows-sized reserve), not inside the Codex sidebar/header.
     style.textContent = `
-      #${buttonId} { -webkit-app-region: no-drag !important; pointer-events: auto !important; position: relative; z-index: 2147483641; display: inline-grid; place-items: center; flex: 0 0 auto; width: 32px; height: 32px; border: 0; border-radius: 8px; padding: 0; margin-inline-start: 8px; margin-inline-end: 18px; background: transparent; color: inherit; cursor: pointer; opacity: .86; user-select: none; transition: background .15s ease, opacity .15s ease, transform .15s ease; }
-      #${buttonId}[data-codey-header-actions="true"] { width: 28px; height: 28px; margin-inline-start: 0; margin-inline-end: 6px; }
-      #${buttonId}:hover { background: rgba(127, 127, 127, .14); opacity: 1; }
+      #${buttonId} {
+        -webkit-app-region: no-drag !important;
+        pointer-events: auto !important;
+        position: fixed !important;
+        z-index: 2147483646 !important;
+        top: max(4px, env(titlebar-area-y, 4px));
+        right: max(
+          ${windowControlsReservePx}px,
+          calc(100vw - env(titlebar-area-x, 0px) - env(titlebar-area-width, 100vw))
+        );
+        display: inline-grid;
+        place-items: center;
+        width: 28px;
+        height: 28px;
+        margin: 0;
+        border: 0;
+        border-radius: 8px;
+        padding: 0;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        opacity: .9;
+        user-select: none;
+        transition: background .15s ease, opacity .15s ease, transform .15s ease;
+      }
+      #${buttonId}:hover { background: rgba(127, 127, 127, .16); opacity: 1; }
       #${buttonId}:active { transform: translateY(1px); }
       #${buttonId}:focus-visible { outline: 2px solid rgba(139, 151, 255, .72); outline-offset: 2px; }
-      #${buttonId} svg { display: block; width: 19px; height: 19px; fill: none; stroke: currentColor; stroke-width: 22; stroke-linecap: round; stroke-linejoin: round; }
+      #${buttonId} svg { display: block; width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 22; stroke-linecap: round; stroke-linejoin: round; }
       #${buttonId} .codey-settings-label { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
-      #${buttonId}::after { content: ""; position: absolute; top: 5px; right: 5px; width: 7px; height: 7px; border-radius: 999px; background: #ff3b30; box-shadow: 0 0 0 2px Canvas; opacity: 0; transform: scale(.7); transition: opacity .15s ease, transform .15s ease; pointer-events: none; }
+      #${buttonId}::after { content: ""; position: absolute; top: 3px; right: 3px; width: 7px; height: 7px; border-radius: 999px; background: #ff3b30; box-shadow: 0 0 0 2px Canvas; opacity: 0; transform: scale(.7); transition: opacity .15s ease, transform .15s ease; pointer-events: none; }
       #${buttonId}[data-codey-update-available="true"]::after { opacity: 1; transform: scale(1); }
-      #${buttonId}[data-codey-header-actions="true"]::after { top: 4px; right: 4px; }
     `;
     document.documentElement.appendChild(style);
   };
@@ -532,91 +555,21 @@
     window.setTimeout?.(scanStatsigUntilReady, 50);
   };
 
-  const visibleMountRect = (element) => {
-    if (!(element instanceof HTMLElement)) return null;
-    if (element.closest("[hidden], [aria-hidden=true]")) return null;
-    const style = window.getComputedStyle(element);
-    const rect = element.getBoundingClientRect();
-    return style.display !== "none"
-      && style.visibility !== "hidden"
-      && rect.width > 0
-      && rect.height > 0
-      ? rect
-      : null;
-  };
-
-  const isTopChromeMountTarget = (element) => {
-    const rect = visibleMountRect(element);
-    if (!rect) return false;
-    const viewportWidth = Math.max(
-      window.innerWidth || 0,
-      document.documentElement?.clientWidth || 0,
-      document.documentElement?.getBoundingClientRect?.().width || 0,
-      rect.right,
-    );
-    return rect.top <= 96
-      && rect.height <= 120
-      && rect.width >= 48
-      && rect.right >= viewportWidth - 48;
-  };
-
-  const findHeaderMount = () => {
-    const header = [...document.querySelectorAll("header")].find(isTopChromeMountTarget)
-      || [...document.querySelectorAll("nav")].find(isTopChromeMountTarget);
-    if (!header) return null;
-
-    const rightmostControl = [...header.querySelectorAll("button, [role=button], a[href]")]
-      .reduce((rightmost, control) => {
-        if (control.id === buttonId) return rightmost;
-        const rect = visibleMountRect(control);
-        if (!rect || (rightmost && rect.right <= rightmost.right)) return rightmost;
-        return { control, right: rect.right };
-      }, null)?.control || null;
-    if (!rightmostControl) return { header, target: header };
-
-    let headerChild = rightmostControl;
-    while (headerChild.parentElement && headerChild.parentElement !== header) {
-      headerChild = headerChild.parentElement;
-    }
-    const headerRect = header.getBoundingClientRect();
-    const childRect = headerChild.getBoundingClientRect();
-    const hasTrailingActionRegion = headerChild !== rightmostControl
-      && childRect.width <= 240
-      && childRect.right >= headerRect.right - 24;
-    return {
-      header,
-      target: header,
-      before: hasTrailingActionRegion ? headerChild : null,
-    };
-  };
-
-  const mountedButtonIsUsable = (button) => {
-    if (headerMountDirty || !(button instanceof HTMLElement) || button.isConnected !== true) {
-      return false;
-    }
-    const parent = button.parentElement;
-    if (!(parent instanceof HTMLElement) || button.closest("[hidden], [aria-hidden=true]")) {
-      return false;
-    }
-    const validParent = parent.matches?.(headerSelector);
-    const anchored = button.dataset.codeyHeaderActions !== "true"
-      || (
-        !!button.nextElementSibling
-        && button.nextElementSibling === button.__codeyHeaderAnchor
-      );
-    return !!validParent && anchored;
-  };
+  const mountedButtonIsUsable = (button) => (
+    button instanceof HTMLElement
+    && button.isConnected === true
+    && button.dataset.codeyWindowChrome === "true"
+    && button.parentElement === document.documentElement
+    && !button.closest?.("[hidden], [aria-hidden=true]")
+  );
 
   const mountButton = () => {
     addStyle();
-    const existingButton = document.getElementById(buttonId);
-    if (mountedButtonIsUsable(existingButton)) return;
-    const mount = findHeaderMount();
-    if (!mount) {
-      existingButton?.remove?.();
+    let button = document.getElementById(buttonId);
+    if (mountedButtonIsUsable(button)) {
+      applyUpdateBadge(button);
       return;
     }
-    let button = existingButton;
     if (!button) {
       button = document.createElement("button");
       button.id = buttonId;
@@ -630,21 +583,12 @@
         openSettings();
       }, true);
     }
-    if (mount.before) {
-      button.dataset.codeyHeaderActions = "true";
-    } else {
-      delete button.dataset.codeyHeaderActions;
+    button.dataset.codeyWindowChrome = "true";
+    delete button.dataset.codeyHeaderActions;
+    if (button.parentElement !== document.documentElement) {
+      document.documentElement.appendChild(button);
     }
-    if (mount.before) {
-      if (button.parentElement !== mount.target || button.nextElementSibling !== mount.before) {
-        mount.target.insertBefore(button, mount.before);
-      }
-    } else if (button.parentElement !== mount.target) {
-      mount.target.appendChild(button);
-    }
-    button.__codeyHeaderAnchor = mount.before || null;
     applyUpdateBadge(button);
-    headerMountDirty = false;
   };
 
   const sidebarDetected = (root = document) => queryWithin(root, sidebarSelector).length > 0;
@@ -721,7 +665,7 @@
   };
 
   const invalidateHeaderMount = (root = document) => {
-    headerMountDirty = true;
+    // Kept for session-tools callers; button no longer depends on header layout.
     scheduleScan(root || document);
   };
 
@@ -743,37 +687,19 @@
         ? mutation.target
         : mutation.target?.parentElement;
       if (mutation.type === "attributes") {
-        if (target?.matches?.(headerSelector) || target?.matches?.(sidebarSelector)) {
-          if (target.matches?.(headerSelector)) headerMountDirty = true;
+        if (target?.matches?.(sidebarSelector)) {
           scheduleScan(target);
           return;
         }
         continue;
       }
-      const targetHeader = target?.matches?.(headerSelector)
-        ? target
-        : target?.closest?.(headerSelector);
-      const headerChildrenChanged = targetHeader && [
-        ...(mutation.addedNodes || []),
-        ...(mutation.removedNodes || []),
-      ].some((node) => node instanceof HTMLElement && node.id !== buttonId);
-      if (headerChildrenChanged) {
-        headerMountDirty = true;
-        scheduleScan(targetHeader);
-        return;
-      }
       for (const node of mutation.addedNodes || []) {
         const element = node instanceof HTMLElement ? node : null;
         if (!element) continue;
-        // One combined probe rejects the overwhelmingly common streaming case
-        // in two subtree walks instead of four.
-        const matched = element.matches?.(bootstrapProbeSelector)
+        const matched = element.matches?.(sidebarSelector)
           ? element
-          : element.querySelector?.(bootstrapProbeSelector);
+          : element.querySelector?.(sidebarSelector);
         if (!matched) continue;
-        if (element.matches?.(headerSelector) || element.querySelector?.(headerSelector)) {
-          headerMountDirty = true;
-        }
         scheduleScan(element);
         return;
       }

--- a/tests/injection-performance.test.mjs
+++ b/tests/injection-performance.test.mjs
@@ -24,18 +24,22 @@ test("renderer core waits for sidebar interaction before loading session tools",
   assert.match(inject, /new MutationObserver\(\(mutations\) =>/);
   assert.match(inject, /scheduleScan\(element\)/);
   assert.match(inject, /const mountedButtonIsUsable = \(button\) =>/);
-  assert.match(inject, /if \(mountedButtonIsUsable\(existingButton\)\) return;/);
-  assert.match(inject, /button\.nextElementSibling === button\.__codeyHeaderAnchor/);
-  assert.match(inject, /const isTopChromeMountTarget = \(element\) =>/);
-  assert.match(inject, /const visibleMountRect = \(element\) =>/);
-  assert.match(inject, /return \{ control, right: rect\.right \};/);
+  assert.match(inject, /if \(mountedButtonIsUsable\(button\)\)/);
+  assert.match(inject, /dataset\.codeyWindowChrome/);
+  assert.match(inject, /windowControlsReservePx = 138/);
+  assert.match(inject, /position: fixed !important/);
+  assert.match(inject, /titlebar-area-width/);
+  assert.doesNotMatch(inject, /findHeaderMount/);
+  assert.doesNotMatch(inject, /isTopChromeMountTarget/);
+  assert.doesNotMatch(inject, /visibleMountRect/);
+  assert.doesNotMatch(inject, /__codeyHeaderAnchor/);
   assert.doesNotMatch(
     inject,
     /control\.getBoundingClientRect\(\)\.right > rightmost\.getBoundingClientRect\(\)\.right/,
   );
   assert.doesNotMatch(inject, /querySelector\("main"\)/);
-  assert.match(inject, /headerMountDirty = true/);
   assert.match(inject, /window\.__codeyRendererInvalidateHeaderMount = invalidateHeaderMount/);
+  assert.doesNotMatch(inject, /headerMountDirty/);
   assert.doesNotMatch(inject, /new MutationObserver\(\(\) => \{[\s\S]*setTimeout\(scan,/);
   assert.doesNotMatch(inject, /characterData:\s*true/);
   assert.doesNotMatch(inject, /mutation\.type === "characterData"/);

--- a/tests/settings-button.test.mjs
+++ b/tests/settings-button.test.mjs
@@ -18,6 +18,8 @@ class FakeElement {
     this.top = top;
     this.style = {};
     this.textContent = "";
+    this.innerHTML = "";
+    this.title = "";
     this.attributes = new Map();
     this.visible = visible;
     this.isConnected = false;
@@ -50,7 +52,10 @@ class FakeElement {
     return child;
   }
 
-  closest() {
+  closest(selector) {
+    if (selector.includes("aria-hidden") && this.getAttribute("aria-hidden") === "true") {
+      return this;
+    }
     return null;
   }
 
@@ -68,31 +73,16 @@ class FakeElement {
       : { bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0 };
   }
 
-  getClientRects() {
-    return this.visible ? [this.getBoundingClientRect()] : [];
+  matches() {
+    return false;
   }
 
   querySelector() {
     return null;
   }
 
-  querySelectorAll(selector) {
-    if (selector !== "button, [role=button], a[href]") return [];
-    const controls = [];
-    const visit = (element) => {
-      for (const child of element.children) {
-        if (child.tagName === "BUTTON") controls.push(child);
-        visit(child);
-      }
-    };
-    visit(this);
-    return controls;
-  }
-
-  matches(selector) {
-    return selector
-      .split(",")
-      .some((part) => part.trim().toUpperCase() === this.tagName);
+  querySelectorAll() {
+    return [];
   }
 
   remove() {
@@ -117,75 +107,7 @@ class FakeElement {
   }
 }
 
-test("moves the Codey button beside the visible header's trailing action region", () => {
-  const hiddenHeader = new FakeElement("header", { visible: false });
-  const visibleHeader = new FakeElement("header", { right: 1200 });
-  const rightRegion = new FakeElement("div", { right: 1200, width: 70 });
-  const actionRow = new FakeElement("div", { right: 1192, width: 62 });
-  const controlWrapper = new FakeElement("span", { right: 1192, width: 28 });
-  const nativeButton = new FakeElement("button", { right: 1192, width: 28 });
-  const codeyButton = new FakeElement("button", { right: 200, width: 32 });
-  codeyButton.id = "codey-settings-button";
-  hiddenHeader.appendChild(codeyButton);
-  visibleHeader.appendChild(rightRegion);
-  rightRegion.appendChild(actionRow);
-  actionRow.appendChild(controlWrapper);
-  controlWrapper.appendChild(nativeButton);
-
-  const placeholders = {
-    "codey-injected-style": new FakeElement("style"),
-    "codey-message-toolbar": new FakeElement(),
-    "codey-settings-button": codeyButton,
-  };
-  const document = {
-    body: new FakeElement("body"),
-    documentElement: new FakeElement("html"),
-    createElement: (tagName) => new FakeElement(tagName),
-    getElementById: (id) => placeholders[id] || null,
-    querySelector: () => null,
-    querySelectorAll: (selector) => (selector === "header" ? [hiddenHeader, visibleHeader] : []),
-  };
-  const window = {
-    addEventListener() {},
-    clearTimeout() {},
-    dispatchEvent() {},
-    getComputedStyle: (element) => ({
-      display: element.visible ? "flex" : "none",
-      visibility: element.visible ? "visible" : "hidden",
-    }),
-    localStorage: { getItem: () => null, key: () => null, length: 0, setItem() {} },
-    setTimeout: () => 1,
-  };
-  window.window = window;
-
-  vm.runInNewContext(source, {
-    console,
-    document,
-    HTMLElement: FakeElement,
-    location: { pathname: "/", search: "" },
-    MutationObserver: class {
-      observe() {}
-    },
-    URLSearchParams,
-    window,
-  });
-
-  assert.equal(codeyButton.parentElement, visibleHeader);
-  assert.equal(codeyButton.dataset.codeyHeaderActions, "true");
-  assert.equal(hiddenHeader.children.includes(codeyButton), false);
-  assert.deepEqual(visibleHeader.children, [codeyButton, rightRegion]);
-});
-
-test("marks the Codey button when a silent update check finds a new version", async () => {
-  const visibleHeader = new FakeElement("header", { right: 1200 });
-  const documentElement = new FakeElement("html");
-  const elementsById = new Map();
-  let nextTimerId = 1;
-  const timers = [];
-  const events = [];
-  const activeTimers = () => timers.filter((timer) => !timer.cleared);
-  const visibleButton = () =>
-    elementsById.get("codey-settings-button") || null;
+function bootRenderer({ documentElement, placeholders = {}, extraWindow = {} }) {
   const document = {
     body: new FakeElement("body"),
     documentElement,
@@ -197,55 +119,34 @@ test("marks the Codey button when a silent update check finds a new version", as
         get: () => id,
         set: (value) => {
           id = String(value);
-          if (id) elementsById.set(id, element);
+          if (id) placeholders[id] = element;
         },
       });
       const originalSetAttribute = element.setAttribute.bind(element);
       element.setAttribute = (name, value) => {
         originalSetAttribute(name, value);
-        if (name === "id") elementsById.set(String(value), element);
+        if (name === "id") placeholders[String(value)] = element;
       };
       return element;
     },
-    getElementById: (id) =>
-      id === "codey-settings-button"
-        ? visibleButton()
-        : elementsById.get(id) || null,
+    getElementById: (id) => placeholders[id] || null,
     querySelector: () => null,
-    querySelectorAll: (selector) =>
-      selector === "header" ? [visibleHeader] : [],
+    querySelectorAll: () => [],
+    addEventListener() {},
+    removeEventListener() {},
   };
   const window = {
-    __codexSessionDeleteBridge: async (path) => {
-      assert.equal(path, "/api/check_for_updates");
-      return {
-        currentVersion: "0.3.9",
-        latestVersion: "0.4.0",
-        updateAvailable: true,
-        selectedAsset: { fileName: "Codey-0.4.0.zip" },
-      };
-    },
     addEventListener() {},
-    alert() {
-      throw new Error("silent update check must not alert");
-    },
-    clearTimeout(id) {
-      const timer = timers.find((entry) => entry.id === id);
-      if (timer) timer.cleared = true;
-    },
-    dispatchEvent(event) {
-      events.push(event);
+    alert() {},
+    clearTimeout() {},
+    dispatchEvent() {
       return true;
     },
     getComputedStyle: () => ({ display: "flex", visibility: "visible" }),
     innerWidth: 1200,
     localStorage: { getItem: () => null, key: () => null, length: 0, setItem() {} },
-    setTimeout(callback, delay) {
-      const timer = { id: nextTimerId, callback, delay, cleared: false };
-      nextTimerId += 1;
-      timers.push(timer);
-      return timer.id;
-    },
+    setTimeout: () => 1,
+    ...extraWindow,
   };
   window.window = window;
 
@@ -267,13 +168,79 @@ test("marks the Codey button when a silent update check finds a new version", as
     window,
   });
 
+  return { document, window, placeholders };
+}
+
+test("mounts the Codey button on the window chrome, left of caption controls", () => {
+  const documentElement = new FakeElement("html", { right: 1200, width: 1200, height: 800 });
+  const sidebar = new FakeElement("nav", { right: 84, width: 84, height: 720 });
+  const staleButton = new FakeElement("button", { right: 40, width: 28 });
+  staleButton.id = "codey-settings-button";
+  sidebar.appendChild(staleButton);
+
+  const placeholders = {
+    "codey-core-injected-style": new FakeElement("style"),
+    "codey-settings-button": staleButton,
+  };
+  const { document } = bootRenderer({ documentElement, placeholders });
+
+  assert.equal(staleButton.parentElement, documentElement);
+  assert.equal(staleButton.dataset.codeyWindowChrome, "true");
+  assert.equal(sidebar.children.includes(staleButton), false);
+  assert.equal(document.documentElement.children.includes(staleButton), true);
+  assert.match(source, /windowControlsReservePx = 138/);
+  assert.match(source, /position: fixed !important/);
+  assert.match(source, /titlebar-area-width/);
+  assert.doesNotMatch(source, /findHeaderMount/);
+  assert.doesNotMatch(source, /isTopChromeMountTarget/);
+});
+
+test("marks the Codey button when a silent update check finds a new version", async () => {
+  const documentElement = new FakeElement("html", { right: 1200, width: 1200 });
+  const placeholders = {};
+  let nextTimerId = 1;
+  const timers = [];
+  const events = [];
+  const activeTimers = () => timers.filter((timer) => !timer.cleared);
+
+  const { window } = bootRenderer({
+    documentElement,
+    placeholders,
+    extraWindow: {
+      __codexSessionDeleteBridge: async (path) => {
+        assert.equal(path, "/api/check_for_updates");
+        return {
+          currentVersion: "0.3.9",
+          latestVersion: "0.4.0",
+          updateAvailable: true,
+          selectedAsset: { fileName: "Codey-0.4.0.zip" },
+        };
+      },
+      clearTimeout(id) {
+        const timer = timers.find((entry) => entry.id === id);
+        if (timer) timer.cleared = true;
+      },
+      dispatchEvent(event) {
+        events.push(event);
+        return true;
+      },
+      setTimeout(callback, delay) {
+        const timer = { id: nextTimerId, callback, delay, cleared: false };
+        nextTimerId += 1;
+        timers.push(timer);
+        return timer.id;
+      },
+    },
+  });
+
   const initialTimer = activeTimers().find((timer) => timer.delay === 0);
   assert.equal(initialTimer?.delay, 0);
   initialTimer.cleared = true;
   initialTimer.callback();
   await new Promise((resolve) => setImmediate(resolve));
-  const button = visibleButton();
+  const button = placeholders["codey-settings-button"];
   assert.ok(button);
+  assert.equal(button.parentElement, documentElement);
   assert.equal(button.getAttribute("data-codey-update-available"), "true");
   assert.equal(button.getAttribute("aria-label"), "打开 Codey 配置，有可用更新");
   assert.equal(window.__codeyUpdateAvailability.latestVersion, "0.4.0");
@@ -285,95 +252,30 @@ test("marks the Codey button when a silent update check finds a new version", as
   );
 });
 
-test("ignores sidebar nav and main content until top chrome is available", () => {
-  const sidebarNav = new FakeElement("nav", { right: 84, width: 84, height: 720 });
-  const main = new FakeElement("main", { right: 1200, width: 1200, height: 640, top: 80 });
-  const mainContent = new FakeElement("div", { right: 1080, width: 960, height: 640, top: 80 });
-  const staleButton = new FakeElement("button", { right: 60, width: 28 });
-  staleButton.id = "codey-settings-button";
-  sidebarNav.appendChild(staleButton);
-  main.appendChild(mainContent);
-
-  let topNav = null;
-  const placeholders = {
-    "codey-core-injected-style": new FakeElement("style"),
-    "codey-settings-button": staleButton,
-  };
-  const document = {
-    body: new FakeElement("body"),
-    documentElement: new FakeElement("html", { right: 1200, width: 1200, height: 800 }),
-    createElement: (tagName) => new FakeElement(tagName),
-    getElementById: (id) => placeholders[id] || null,
-    querySelector: (selector) => (selector === "main" ? main : null),
-    querySelectorAll: (selector) => {
-      if (selector === "header") return [];
-      if (selector === "nav") return topNav ? [sidebarNav, topNav] : [sidebarNav];
-      return [];
-    },
-  };
-  const window = {
-    addEventListener() {},
-    alert() {},
-    clearTimeout() {},
-    getComputedStyle: (element) => ({
-      display: element.visible ? "flex" : "none",
-      visibility: element.visible ? "visible" : "hidden",
-    }),
-    innerWidth: 1200,
-    setTimeout: () => 1,
-  };
-  window.window = window;
-
-  vm.runInNewContext(source, {
-    console,
-    document,
-    HTMLElement: FakeElement,
-    location: { pathname: "/", search: "" },
-    MutationObserver: class {
-      observe() {}
-    },
-    URLSearchParams,
-    window,
-  });
-
-  assert.equal(staleButton.parentElement, null);
-  assert.equal(sidebarNav.children.includes(staleButton), false);
-  assert.equal(mainContent.children.length, 0);
-
-  topNav = new FakeElement("nav", { right: 1200, width: 96, height: 46 });
-  window.__codeyRendererScan();
-
-  assert.equal(staleButton.parentElement, topNav);
-  assert.deepEqual(topNav.children, [staleButton]);
-});
-
-test("repeated scans fast-path an already mounted button without layout reads", () => {
-  const visibleHeader = new FakeElement("header", { right: 1200 });
-  const rightRegion = new FakeElement("div", { right: 1200, width: 70 });
-  const nativeButton = new FakeElement("button", { right: 1192, width: 28 });
-  const codeyButton = new FakeElement("button", { right: 1120, width: 28 });
+test("repeated scans fast-path an already mounted window-chrome button", () => {
+  const documentElement = new FakeElement("html", { right: 1200, width: 1200 });
+  const codeyButton = new FakeElement("button", { right: 1060, width: 28 });
   codeyButton.id = "codey-settings-button";
-  codeyButton.dataset.codeyHeaderActions = "true";
-  codeyButton.isConnected = true;
-  visibleHeader.appendChild(codeyButton);
-  visibleHeader.appendChild(rightRegion);
-  rightRegion.appendChild(nativeButton);
+  codeyButton.dataset.codeyWindowChrome = "true";
+  documentElement.appendChild(codeyButton);
 
   const placeholders = {
     "codey-core-injected-style": new FakeElement("style"),
     "codey-settings-button": codeyButton,
   };
-  let headerQueries = 0;
+  let createCount = 0;
   const document = {
     body: new FakeElement("body"),
-    documentElement: new FakeElement("html"),
-    createElement: (tagName) => new FakeElement(tagName),
+    documentElement,
+    createElement: (tagName) => {
+      createCount += 1;
+      return new FakeElement(tagName);
+    },
     getElementById: (id) => placeholders[id] || null,
     querySelector: () => null,
-    querySelectorAll: (selector) => {
-      if (selector === "header" || selector === "nav") headerQueries += 1;
-      return selector === "header" ? [visibleHeader] : [];
-    },
+    querySelectorAll: () => [],
+    addEventListener() {},
+    removeEventListener() {},
   };
   const window = {
     addEventListener() {},
@@ -383,7 +285,6 @@ test("repeated scans fast-path an already mounted button without layout reads", 
     setTimeout: () => 1,
   };
   window.window = window;
-  let observerCallback = null;
 
   vm.runInNewContext(source, {
     console,
@@ -391,44 +292,17 @@ test("repeated scans fast-path an already mounted button without layout reads", 
     HTMLElement: FakeElement,
     location: { pathname: "/", search: "" },
     MutationObserver: class {
-      constructor(callback) {
-        observerCallback = callback;
-      }
-
       observe() {}
     },
     URLSearchParams,
     window,
   });
 
-  headerQueries = 0;
-  for (const element of [visibleHeader, rightRegion, nativeButton, codeyButton]) {
-    element.rectReads = 0;
-  }
+  createCount = 0;
   for (let scan = 0; scan < 10; scan += 1) {
     window.__codeyRendererScan();
   }
-  assert.equal(headerQueries, 0);
-  assert.equal(visibleHeader.rectReads, 0);
-  assert.equal(rightRegion.rectReads, 0);
-  assert.equal(nativeButton.rectReads, 0);
-  assert.equal(codeyButton.rectReads, 0);
-  assert.deepEqual(visibleHeader.children, [codeyButton, rightRegion]);
-
-  const newRightRegion = new FakeElement("div", { right: 1200, width: 50 });
-  const newRightButton = new FakeElement("button", { right: 1200, width: 28 });
-  newRightRegion.appendChild(newRightButton);
-  visibleHeader.appendChild(newRightRegion);
-  observerCallback([{
-    type: "childList",
-    target: visibleHeader,
-    addedNodes: [newRightRegion],
-    removedNodes: [],
-  }]);
-  window.__codeyRendererScan();
-
-  assert.ok(headerQueries > 0);
-  assert.equal(codeyButton.__codeyHeaderAnchor, newRightRegion);
-  assert.equal(codeyButton.dataset.codeyHeaderActions, "true");
-  assert.deepEqual(visibleHeader.children, [rightRegion, codeyButton, newRightRegion]);
+  assert.equal(createCount, 0);
+  assert.equal(codeyButton.parentElement, documentElement);
+  assert.equal(codeyButton.dataset.codeyWindowChrome, "true");
 });


### PR DESCRIPTION
## Summary
- Pin the Codey settings button to the top-right, left of window min/max/close controls.
- Remove sidebar/header mount behavior from the renderer inject path.

## Test plan
- [x] Button appears beside window controls
- [x] Click still toggles settings overlay
- [x] Inject/performance related tests pass