### PR TITLE
fix: Codex 启动卡死自动恢复，watchdog 巡检提速到 5 秒

### DIFF
--- a/backend/src/commands.rs
+++ b/backend/src/commands.rs
@@ -222,13 +222,28 @@ impl AppState {
             return invoke_api(self, command, payload).await;
         }
         match path.as_str() {
-            "/diagnostics/error" => match error_log::record_renderer_failure(&payload) {
-                Ok(()) => json!({
-                    "status": "ok",
-                    "message": "Renderer 错误诊断已记录",
-                }),
-                Err(error) => api_error_message(error),
-            },
+            "/diagnostics/error" => {
+                let recorded = error_log::record_renderer_failure(&payload);
+                // 启动卡死自动恢复：渲染进程上报 host shell 启动超时后，
+                // 由 Codey 主动 reload 页面一次（全程仅一次），watchdog 会在
+                // 数秒内重建桥接；网络抖动等临时故障恢复后主界面即可自愈。
+                if payload
+                    .get("operation")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("wait_for_codex_host_shell")
+                {
+                    if let Some(runtime) = self.runtime.lock().await.as_ref() {
+                        runtime.maybe_recover_startup_stall().await;
+                    }
+                }
+                match recorded {
+                    Ok(()) => json!({
+                        "status": "ok",
+                        "message": "Renderer 错误诊断已记录",
+                    }),
+                    Err(error) => api_error_message(error),
+                }
+            }
             "/settings/get" => {
                 let config = self.config.read().await;
                 serde_json::to_value(redacted_config(&config))

--- a/backend/src/launcher.rs
+++ b/backend/src/launcher.rs
@@ -35,7 +35,9 @@ use crate::session_index_cleanup::{self, SessionIndexCleanupReport};
 use crate::startup_maintenance::{self, ProviderSyncPlan};
 use crate::trace_log_guard;
 
-const CDP_WATCHDOG_INTERVAL: Duration = Duration::from_secs(30);
+// Codex 渲染进程导航（自动恢复 reload、ChatGPT 内部跳转等）会使桥接丢失，
+// 缩短巡检周期让注入在 10 秒内自动重建，避免长时间失去 Codey 按钮与桥。
+const CDP_WATCHDOG_INTERVAL: Duration = Duration::from_secs(5);
 const CDP_WATCHDOG_FAILURE_THRESHOLD: u8 = 2;
 const ROUTE_OVERLAY_WATCH_INTERVAL: Duration = Duration::from_secs(1);
 pub const CODEX_APP_NOT_FOUND_ERROR: &str = "找不到 Codex App，请在 Codey 配置中填写路径";
@@ -143,12 +145,46 @@ pub struct CodeyRuntime {
     route_overlay_shutdown: Mutex<Option<oneshot::Sender<()>>>,
     route_overlay_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     exit_watchdog_shutdown: Mutex<Option<oneshot::Sender<()>>>,
+    // 启动卡死自动恢复只执行一次，避免 reload 循环。
+    startup_recovery_attempted: AtomicBool,
 }
 
 impl CodeyRuntime {
     pub async fn renderer_websocket_url(&self) -> Arc<str> {
         self.injection_websocket_url.read().await.clone()
     }
+
+    /// Codex 主界面在启动超时（startup_stalled）后执行一次自动恢复：
+    /// 重新加载渲染进程页面。页面 reload 后 Codey 的桥接会短暂丢失，
+    /// 由 CDP watchdog 在数秒内自动重建注入；同时已注册的
+    /// Page.addScriptToEvaluateOnNewDocument 会让新文档在 document_start
+    /// 阶段提前安装 fast-startup-shield，覆盖启动阶段的 Statsig 初始化。
+    pub async fn maybe_recover_startup_stall(&self) {
+        if self.startup_recovery_attempted.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let websocket_url = self.injection_websocket_url.read().await.clone();
+        error_log::record_failure(
+            "startup_recovery",
+            "reload_codex_after_startup_stall",
+            "Codex 主界面在启动时限内未就绪，Codey 已自动重新加载页面一次以尝试恢复渲染",
+            serde_json::json!({}),
+        );
+        if let Err(error) = codey_runtime_core::bridge::evaluate_script(
+            &websocket_url,
+            "window.location.reload()",
+        )
+        .await
+        {
+            error_log::record_failure(
+                "startup_recovery_failed",
+                "reload_codex_after_startup_stall",
+                format!("自动重新加载 Codex 页面失败：{error:#}"),
+                serde_json::json!({}),
+            );
+        }
+    }
+
 
     pub async fn applied_model_config(&self) -> RuntimeModelConfig {
         self.applied_model_config.read().await.clone()
@@ -857,6 +893,7 @@ impl CodeyRuntime {
                 route_overlay_shutdown: Mutex::new(route_overlay_shutdown),
                 route_overlay_task: Mutex::new(route_overlay_task),
                 exit_watchdog_shutdown: Mutex::new(Some(exit_watchdog_shutdown)),
+                startup_recovery_attempted: AtomicBool::new(false),
             },
             codex_exit,
         ))


### PR DESCRIPTION
## 背景

排查 Codex 启动卡在 loading 页的问题时发现（详细过程见 #15 关联排查）：

- Codex 渲染进程启动超时（20 秒内主界面未渲染，即 renderer 上报 `wait_for_codex_host_shell`）时，Codey 此前**只记录错误日志，没有任何恢复动作**，用户只能手动退出重开。
- CDP watchdog 巡检周期 30 秒且需连续 2 次失败才重注入，页面导航/重载导致桥接丢失后要 **60 秒以上**才能恢复注入（实测确认）。

## 改动

- `commands.rs`：`/diagnostics/error` 识别 `wait_for_codex_host_shell` 后，由 Codey 主动 reload 渲染进程页面**一次**（AtomicBool 防循环）。网络抖动等临时故障恢复后主界面可自愈；reload 产生的新文档会在 document_start 阶段执行已注册的 `Page.addScriptToEvaluateOnNewDocument` 脚本，提前安装启动保护（fast-startup-shield 等）。
- `launcher.rs`：CDP watchdog 巡检周期 30s → 5s，导航/自动恢复 reload 后桥接在 10 秒内自动重建；新增 `CodeyRuntime::maybe_recover_startup_stall()`，恢复动作记录到错误日志便于诊断。

## 验证

- `cargo check` 通过，全量测试 303 通过
- 恢复链路已实证：页面 reload 后 watchdog 能自动重建注入（原 30s 周期下 60s+ 恢复，提速后 10s 内）