### PR TITLE
fix: keep updated Codex avatar controller available

### DIFF
--- a/INTERNAL_DEVELOPMENT.md
+++ b/INTERNAL_DEVELOPMENT.md
@@ -102,7 +102,7 @@ Codey 将运行时 core/data crate 固定在 `vendor/CodeyRuntime`，生命周�
 - Codex 配置：使用 Codex 默认 `CODEX_HOME`（通常是 `~/.codex`）。
 - Trace 写盘防护由 `disableTraceLogWrites` 控制，默认开启；macOS / Windows 使用相同启动时机更新 Codex 根目录及旧版 `sqlite/` 目录中现有的 `logs_*.sqlite`，不会创建、清空或压缩日志库。macOS Crashpad 容量保护由独立的 `protectCrashpadPending` 控制，默认开启且保存后热切换；Windows 保留兼容配置字段但不扫描 Crashpad 目录。
 - Windows 卡顿补丁不设开关：Codey 在运行时识别 Windows，并在每次启动 Codex 时自动隔离 Micro 设备模块和周期性 WMI 进程采样。启动 Codey 时若目标 Codex 主进程已在运行，会先终止该安装目录下的 Codex 进程树，确认退出后再拉起新主进程，确保补丁能在主进程执行前安装；清理失败会中止启动。macOS 不执行 Windows 专属分支。
-- 宠物硬阉割：`slimCodexPet` 默认为 `true`，macOS / Windows 都会在下次通过 Codey 启动 Codex 时生效。启用时若主 bundle 的语义锚点因官方升级而变化，Windows 会清理暂停实例后以兼容模式启动，并将宠物精简状态显示为失败；macOS 则停止启动。关闭后下次启动会恢复完整宠物功能。
+- 宠物硬阉割：`slimCodexPet` 默认为 `false`。为兼容需要 Avatar Overlay 控制器的新 Codex 启动流程，读取到旧配置中的 `true` 时会自动迁移为 `false`；关闭后下次启动会恢复完整宠物功能。
 - 语音精简：`slimCodexVoice` 默认为 `false`，macOS / Windows 都会在下次通过 Codey 启动 Codex 时生效。开启后同时覆盖旧听写和新版 GPT Voice / Realtime Voice；关闭时保留完整语音功能。
 - 浮动额度：`showAccountUsageInHeader` 默认为 `true`，保存后立即生效且不要求重启。只有活动线路被识别为官方账号登录时才请求并展示，切到第三方线路后保留开关值但停止请求和显示；用户手动关闭后的持久化值不会被默认值覆盖。
 - Codex 慢启动保护：`fastCodexStartup` 默认为 `true`。Codey 会在 Electron 主进程仍处于启动暂停阶段时，为登录后的 Statsig bootstrap 设置 1.5 秒上限，并保留 renderer 保护作为兼容兜底；正常响应保持原流程，慢请求或失败请求会让 Codex 使用自身错误降级路径继续挂载主界面。原始初始化仍可在后续刷新中恢复；关闭后下次启动完全使用 Codex 原生等待策略。

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -99,7 +99,7 @@ pub struct CodeyConfig {
     /// budget. The guard only manages validated report files on macOS.
     #[serde(default = "default_true")]
     pub protect_crashpad_pending: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub slim_codex_pet: bool,
     #[serde(default)]
     pub slim_codex_voice: bool,
@@ -160,7 +160,10 @@ impl Default for CodeyConfig {
             default_model_by_provider: BTreeMap::new(),
             disable_trace_log_writes: true,
             protect_crashpad_pending: true,
-            slim_codex_pet: true,
+            // Newer Codex builds initialize the avatar-overlay voice controller
+            // during startup; blocking the native pet surface breaks that
+            // required registration path. Keep the compatibility patch opt-in.
+            slim_codex_pet: false,
             slim_codex_voice: false,
             gpu_launch_mode: GpuLaunchMode::Off,
             fast_context_tools: false,
@@ -359,8 +362,14 @@ impl ConfigStore {
     pub fn load(&self) -> Result<CodeyConfig> {
         match fs::read_to_string(&self.path) {
             Ok(contents) => {
-                let config = serde_json::from_str::<CodeyConfig>(&contents)
+                let mut config = serde_json::from_str::<CodeyConfig>(&contents)
                     .with_context(|| format!("解析 Codey 配置失败：{}", self.path.display()))?;
+                // Codex now requires the avatar-overlay controller during startup.
+                // Migrate persisted legacy pet-slim settings before launching it.
+                if config.slim_codex_pet {
+                    config.slim_codex_pet = false;
+                    self.save(&config)?;
+                }
                 Ok(config.normalize())
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -562,12 +571,12 @@ mod tests {
     }
 
     #[test]
-    fn pet_slim_mode_defaults_to_enabled_for_existing_configs() {
+    fn pet_slim_mode_defaults_to_disabled_for_existing_configs() {
         let config = serde_json::from_str::<CodeyConfig>(r#"{"activeProfileId":"","profiles":[]}"#)
             .unwrap()
             .normalize();
 
-        assert!(config.slim_codex_pet);
+        assert!(!config.slim_codex_pet);
     }
 
     #[test]
@@ -579,6 +588,24 @@ mod tests {
         .normalize();
 
         assert!(!config.slim_codex_pet);
+    }
+
+    #[test]
+    fn legacy_pet_slim_mode_is_migrated_when_loading() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("config.json");
+        fs::write(
+            &path,
+            br#"{"activeProfileId":"","profiles":[],"slimCodexPet":true}"#,
+        )
+        .unwrap();
+
+        let store = ConfigStore::new(&path);
+        let config = store.load().unwrap();
+        assert!(!config.slim_codex_pet);
+
+        let saved = serde_json::from_slice::<serde_json::Value>(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(saved["slimCodexPet"], false);
     }
 
     #[test]

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -81,7 +81,7 @@ if (import.meta.env.DEV) {
       defaultModelByProvider: {},
       disableTraceLogWrites: true,
       protectCrashpadPending: true,
-      slimCodexPet: true,
+      slimCodexPet: false,
       slimCodexVoice: false,
       gpuLaunchMode: "off" as const,
       fastContextTools: false,


### PR DESCRIPTION
## Summary

Fixes #21.

New Codex desktop builds initialize the Avatar Overlay voice controller during startup. Codey previously defaulted `slimCodexPet` to enabled and blocked the native avatar surface, which caused Codey to fail with `Avatar overlay voice controller is unavailable`.

This change:
- disables pet slimming by default in Rust and the development preview;
- migrates existing persisted `slimCodexPet: true` settings to `false` during config load;
- documents the compatibility behavior.

## Validation

- `cargo fmt --all -- --check`
- `node --test tests/windows-wmi-patch.test.mjs`
- 157 JavaScript tests passed in `npm run test:js`; 2 tests could not load because the workspace is missing `vite` and `typescript`.
- Rust tests were not runnable with the installed Rust 1.85.0 because current dependencies require Rust 1.88+.