### PR TITLE
Fix local route proxy bypass and CLI wrapper handshake race

### DIFF
--- a/backend/src/codex_startup_patch.rs
+++ b/backend/src/codex_startup_patch.rs
@@ -39,6 +39,12 @@ pub(crate) const CLI_WRAPPER_TOKEN_ENV: &str = "CODEY_CODEX_CLI_WRAPPER_TOKEN";
 /// 包装器执行记录文件的绝对路径；回环握手丢失时启动器据此确认目标已执行。
 #[cfg(any(windows, target_os = "macos"))]
 pub(crate) const CLI_WRAPPER_MARKER_ENV: &str = "CODEY_CODEX_CLI_WRAPPER_MARKER";
+/// When Inspector installation may win the startup race, the wrapper records
+/// progress through its marker only and does not connect a listener that the
+/// launcher can drop after Inspector success.
+#[cfg(any(windows, target_os = "macos"))]
+pub(crate) const CLI_WRAPPER_HANDSHAKE_OPTIONAL_ENV: &str =
+    "CODEY_CODEX_CLI_WRAPPER_HANDSHAKE_OPTIONAL";
 #[cfg(any(windows, target_os = "macos", test))]
 const CLI_WRAPPER_HANDSHAKE_CONNECT_TIMEOUT: std::time::Duration =
     std::time::Duration::from_millis(500);
@@ -401,6 +407,7 @@ pub fn run_cli_wrapper_if_requested() -> Result<bool> {
             CLI_WRAPPER_PORT_ENV,
             CLI_WRAPPER_TOKEN_ENV,
             CLI_WRAPPER_MARKER_ENV,
+            CLI_WRAPPER_HANDSHAKE_OPTIONAL_ENV,
         ] {
             command.env_remove(name);
         }
@@ -613,11 +620,43 @@ impl CliWrapperReadiness {
     fn begin() -> Self {
         let started = std::time::Instant::now();
         let marker = cli_wrapper_marker_path_from_env(std::env::var_os(CLI_WRAPPER_MARKER_ENV));
+        let handshake_required = cli_wrapper_handshake_required(
+            std::env::var_os(CLI_WRAPPER_HANDSHAKE_OPTIONAL_ENV).as_deref(),
+        );
+        Self::begin_with_diagnostics(
+            marker,
+            handshake_required,
+            started,
+            connect_cli_wrapper_handshake,
+        )
+    }
+
+    #[cfg(test)]
+    fn begin_with(
+        marker: Option<std::path::PathBuf>,
+        handshake_required: bool,
+        connect: impl FnOnce() -> Result<std::net::TcpStream>,
+    ) -> Self {
+        Self::begin_with_diagnostics(
+            marker,
+            handshake_required,
+            std::time::Instant::now(),
+            connect,
+        )
+    }
+
+    fn begin_with_diagnostics(
+        marker: Option<std::path::PathBuf>,
+        handshake_required: bool,
+        started: std::time::Instant,
+        connect: impl FnOnce() -> Result<std::net::TcpStream>,
+    ) -> Self {
         let _ = codey_runtime_core::diagnostic_log::append_diagnostic_log(
             "launcher.cli_wrapper_started",
             serde_json::json!({
                 "pid": std::process::id(),
                 "markerPresent": marker.is_some(),
+                "handshakeRequired": handshake_required,
             }),
         );
         let readiness = Self {
@@ -625,22 +664,26 @@ impl CliWrapperReadiness {
             marker,
         };
         readiness.mark(CliWrapperMarkerStatus::Launching, None);
-        let stream = match connect_cli_wrapper_handshake() {
-            Ok(stream) => Some(stream),
-            Err(error) => {
-                // 端口被拒绝说明启动器已不再监听（例如 app-server 重启），属正常情况。
-                if error
-                    .downcast_ref::<std::io::Error>()
-                    .is_none_or(|error| error.kind() != std::io::ErrorKind::ConnectionRefused)
-                {
-                    crate::error_log::record_failure(
-                        "compatibility_fallback",
-                        "connect_cli_wrapper_handshake",
-                        format!("{error:#}"),
-                        serde_json::json!({ "markerPresent": readiness.marker.is_some() }),
-                    );
+        let stream = if !handshake_required {
+            None
+        } else {
+            match connect() {
+                Ok(stream) => Some(stream),
+                Err(error) => {
+                    // 端口被拒绝说明启动器已不再监听（例如 app-server 重启），属正常情况。
+                    if error
+                        .downcast_ref::<std::io::Error>()
+                        .is_none_or(|error| error.kind() != std::io::ErrorKind::ConnectionRefused)
+                    {
+                        crate::error_log::record_failure(
+                            "compatibility_fallback",
+                            "connect_cli_wrapper_handshake",
+                            format!("{error:#}"),
+                            serde_json::json!({ "markerPresent": readiness.marker.is_some() }),
+                        );
+                    }
+                    None
                 }
-                None
             }
         };
         let _ = codey_runtime_core::diagnostic_log::append_diagnostic_log(
@@ -691,6 +734,11 @@ impl CliWrapperReadiness {
     fn executed(self) {
         self.mark_executed();
     }
+}
+
+#[cfg(any(windows, target_os = "macos", test))]
+fn cli_wrapper_handshake_required(optional: Option<&OsStr>) -> bool {
+    optional != Some(OsStr::new("1"))
 }
 
 #[cfg(any(windows, target_os = "macos"))]
@@ -1216,6 +1264,25 @@ fn ensure_protocol_success(payload: &serde_json::Value, method: &str) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn optional_cli_wrapper_handshake_writes_marker_without_connecting() {
+        let temporary = tempfile::tempdir().unwrap();
+        let marker_path = temporary.path().join("wrapper.json");
+        let readiness = CliWrapperReadiness::begin_with(Some(marker_path.clone()), false, || {
+            panic!("an Inspector-capable launch must not open a discarded handshake listener")
+        });
+        assert!(readiness.stream.is_none());
+        assert_eq!(
+            CliWrapperMarker::read(&marker_path)
+                .unwrap()
+                .unwrap()
+                .status,
+            CliWrapperMarkerStatus::Launching
+        );
+        assert!(cli_wrapper_handshake_required(Some(OsStr::new("0"))));
+        assert!(!cli_wrapper_handshake_required(Some(OsStr::new("1"))));
+    }
 
     #[test]
     fn cli_input_routes_thread_requests_and_preserves_other_protocol_messages() {

--- a/backend/src/commands/prompt_optimization.rs
+++ b/backend/src/commands/prompt_optimization.rs
@@ -14,19 +14,29 @@ use crate::local_router;
 use crate::prompt_optimization;
 
 static OPTIMIZER_CLIENT: OnceLock<Client> = OnceLock::new();
+static LOOPBACK_OPTIMIZER_CLIENT: OnceLock<Client> = OnceLock::new();
 const CODEX_INSTALLATION_ID_HEADER: &str = "x-codex-installation-id";
 const CODEX_INSTALLATION_ID_FILE: &str = "installation_id";
 const AUTHORIZATION_HEADER: &str = "authorization";
 const CHATGPT_ACCOUNT_ID_HEADER: &str = "chatgpt-account-id";
 
-fn optimizer_client() -> Result<&'static Client, String> {
-    if let Some(client) = OPTIMIZER_CLIENT.get() {
+fn optimizer_client(uses_codey_route: bool) -> Result<&'static Client, String> {
+    let slot = if uses_codey_route {
+        &LOOPBACK_OPTIMIZER_CLIENT
+    } else {
+        &OPTIMIZER_CLIENT
+    };
+    if let Some(client) = slot.get() {
         return Ok(client);
     }
-    let client = prompt_optimization::optimizer_http_client()?;
+    let client = if uses_codey_route {
+        prompt_optimization::loopback_optimizer_http_client()?
+    } else {
+        prompt_optimization::optimizer_http_client()?
+    };
     // Concurrent callers may build a duplicate client; the first successful
     // one wins and the rest reuse it.
-    Ok(OPTIMIZER_CLIENT.get_or_init(|| client))
+    Ok(slot.get_or_init(|| client))
 }
 
 async fn resolve_request_config(
@@ -147,8 +157,9 @@ pub async fn optimize_prompt_command(state: &Arc<AppState>, text: String) -> Res
     if !optimization.enabled {
         return Err("提示词优化尚未启用，请先在 Codey 控制台开启".to_string());
     }
+    let uses_codey_route = optimization.uses_codey_route();
     let request_config = resolve_request_config(state, &optimization).await?;
-    let client = optimizer_client()?;
+    let client = optimizer_client(uses_codey_route)?;
     match prompt_optimization::optimize_prompt_resolved(client, &request_config, &text).await {
         Ok(optimized) => Ok(json!({"optimized": optimized})),
         Err(error) => {
@@ -176,8 +187,9 @@ pub async fn fetch_prompt_optimization_models_command(
     let mut optimization = draft.unwrap_or_else(|| config.prompt_optimization.clone());
     optimization.merge_redacted_secrets(&config.prompt_optimization);
     optimization.validate()?;
+    let uses_codey_route = optimization.uses_codey_route();
     let request_config = resolve_request_config(state, &optimization).await?;
-    let client = optimizer_client()?;
+    let client = optimizer_client(uses_codey_route)?;
     let models = prompt_optimization::fetch_models_resolved(client, &request_config).await;
     match models {
         Ok(models) => Ok(json!({"models": models})),
@@ -204,8 +216,9 @@ pub async fn test_prompt_optimization_command(
     let mut optimization = draft.unwrap_or_else(|| config.prompt_optimization.clone());
     optimization.merge_redacted_secrets(&config.prompt_optimization);
     optimization.validate()?;
+    let uses_codey_route = optimization.uses_codey_route();
     let request_config = resolve_request_config(state, &optimization).await?;
-    let client = optimizer_client()?;
+    let client = optimizer_client(uses_codey_route)?;
     match prompt_optimization::test_configuration_resolved(client, &request_config).await {
         Ok(result) => Ok(json!({"status": "ok", "result": result})),
         Err(error) => {

--- a/backend/src/launcher/process.rs
+++ b/backend/src/launcher/process.rs
@@ -193,21 +193,25 @@ pub(super) async fn spawn_codex(
                 crate::electron_fuses::detect_node_cli_inspect_state(app_dir.to_path_buf()).await;
             let cli_only = retry_without_inspector || !inspect_fuse.inspector_possible();
 
-            let (wrapper, wrapper_preparation_error) =
-                match prepare_cli_wrapper(app_dir, subagent_gate_active, runtime_config_overrides)
-                    .await
-                {
-                    Ok(wrapper) => (Some(wrapper), None),
-                    Err(error) => {
-                        error_log::record_failure(
-                            "compatibility_fallback",
-                            "prepare_windows_codex_cli_wrapper",
-                            format!("{error:#}"),
-                            serde_json::json!({ "platform": "windows" }),
-                        );
-                        (None, Some(error))
-                    }
-                };
+            let (wrapper, wrapper_preparation_error) = match prepare_cli_wrapper(
+                app_dir,
+                subagent_gate_active,
+                runtime_config_overrides,
+                !cli_only,
+            )
+            .await
+            {
+                Ok(wrapper) => (Some(wrapper), None),
+                Err(error) => {
+                    error_log::record_failure(
+                        "compatibility_fallback",
+                        "prepare_windows_codex_cli_wrapper",
+                        format!("{error:#}"),
+                        serde_json::json!({ "platform": "windows" }),
+                    );
+                    (None, Some(error))
+                }
+            };
             let inspector_port = if cli_only {
                 None
             } else {
@@ -472,9 +476,13 @@ pub(super) async fn spawn_codex(
             build_codex_command(app_dir, debug_port, &launch_arguments)
         };
         let wrapper = if app_dir.extension().and_then(|value| value.to_str()) == Some("app") {
-            let wrapper =
-                prepare_cli_wrapper(app_dir, subagent_gate_active, runtime_config_overrides)
-                    .await?;
+            let wrapper = prepare_cli_wrapper(
+                app_dir,
+                subagent_gate_active,
+                runtime_config_overrides,
+                inspect_fuse.inspector_possible(),
+            )
+            .await?;
             add_macos_cli_wrapper(&mut command, &wrapper.environment)?;
             Some(wrapper)
         } else {
@@ -930,6 +938,7 @@ async fn prepare_cli_wrapper(
     app_dir: &std::path::Path,
     subagent_gate_active: bool,
     runtime_config_overrides: &[String],
+    handshake_optional: bool,
 ) -> Result<CliWrapperLaunch> {
     let codey = std::env::current_exe().context("定位 Codey 兼容执行器失败")?;
     #[cfg(windows)]
@@ -977,10 +986,21 @@ async fn prepare_cli_wrapper(
             marker_path.to_string_lossy().to_string(),
         ),
     ];
+    if handshake_optional {
+        environment.push((
+            crate::codex_startup_patch::CLI_WRAPPER_HANDSHAKE_OPTIONAL_ENV.to_string(),
+            "1".to_string(),
+        ));
+    }
     if crate::codex_startup_patch::local_router_runtime_enabled(runtime_config_overrides) {
         // Applies before Desktop chooses a transport, including CLI fallback
         // launches where the inspector patch cannot set this environment.
         environment.push(("CODEX_APP_SERVER_FORCE_CLI".to_string(), "1".to_string()));
+        environment.extend(local_router_proxy_bypass_environment(
+            runtime_config_overrides,
+            std::env::var("NO_PROXY").ok().as_deref(),
+            std::env::var("no_proxy").ok().as_deref(),
+        ));
     }
     #[cfg(windows)]
     let wrapper = codey;
@@ -1003,6 +1023,64 @@ async fn prepare_cli_wrapper(
         marker_path,
         environment,
     })
+}
+
+/// Local routing terminates at Codey's loopback listener. Keep that hop out of
+/// the user's system proxy while preserving every existing bypass rule. Windows
+/// treats environment keys case-insensitively, so it receives one canonical key.
+#[cfg(any(windows, target_os = "macos", test))]
+fn local_router_proxy_bypass_environment(
+    runtime_config_overrides: &[String],
+    no_proxy: Option<&str>,
+    lowercase_no_proxy: Option<&str>,
+) -> Vec<(String, String)> {
+    if !crate::codex_startup_patch::local_router_runtime_enabled(runtime_config_overrides) {
+        return Vec::new();
+    }
+    #[cfg(windows)]
+    {
+        vec![(
+            "NO_PROXY".to_string(),
+            merge_loopback_no_proxy(no_proxy.or(lowercase_no_proxy)),
+        )]
+    }
+    #[cfg(target_os = "macos")]
+    {
+        vec![
+            ("NO_PROXY".to_string(), merge_loopback_no_proxy(no_proxy)),
+            (
+                "no_proxy".to_string(),
+                merge_loopback_no_proxy(lowercase_no_proxy.or(no_proxy)),
+            ),
+        ]
+    }
+    #[cfg(not(any(windows, target_os = "macos")))]
+    {
+        let _ = (no_proxy, lowercase_no_proxy);
+        Vec::new()
+    }
+}
+
+#[cfg(any(windows, target_os = "macos", test))]
+fn merge_loopback_no_proxy(existing: Option<&str>) -> String {
+    const LOOPBACK: [&str; 3] = ["127.0.0.1", "localhost", "::1"];
+    let mut entries = existing
+        .into_iter()
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    for required in LOOPBACK {
+        if !entries.iter().any(|entry| {
+            entry
+                .trim_matches(['[', ']'])
+                .eq_ignore_ascii_case(required)
+        }) {
+            entries.push(required.to_string());
+        }
+    }
+    entries.join(",")
 }
 
 #[cfg(any(windows, target_os = "macos", test))]
@@ -1692,6 +1770,23 @@ fn spawn_command(command: Vec<String>) -> Result<SpawnedCodex> {
 #[cfg(test)]
 mod cli_wrapper_tests {
     use super::*;
+
+    #[test]
+    fn local_router_proxy_bypass_merges_loopback_entries_without_changing_direct_mode() {
+        let inherited = Some("corp.internal,127.0.0.1");
+        let router = vec!["model_provider=codey_router".to_string()];
+        let direct = vec!["model_provider=openai".to_string()];
+
+        let enabled = local_router_proxy_bypass_environment(&router, inherited, None);
+        assert_eq!(
+            enabled.len(),
+            1,
+            "Windows must not receive case-conflicting proxy variables"
+        );
+        assert_eq!(enabled[0].0, "NO_PROXY");
+        assert_eq!(enabled[0].1, "corp.internal,127.0.0.1,localhost,::1");
+        assert!(local_router_proxy_bypass_environment(&direct, inherited, None).is_empty());
+    }
 
     // 【自动化测试】启动 - 查询失败不报告退出，真实退出仍立即识别
     #[test]

--- a/backend/src/prompt_optimization.rs
+++ b/backend/src/prompt_optimization.rs
@@ -114,17 +114,41 @@ fn optimization_upstream_protocol(
     }
 }
 
+#[derive(Clone, Copy)]
+enum OptimizerProxyMode {
+    System,
+    Disabled,
+}
+
+fn build_optimizer_http_client(
+    builder: reqwest::ClientBuilder,
+    proxy_mode: OptimizerProxyMode,
+) -> Result<Client, String> {
+    let builder = builder
+        .user_agent(format!("Codey/{}", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(Duration::from_secs(15))
+        .redirect(reqwest::redirect::Policy::none());
+    let builder = match proxy_mode {
+        OptimizerProxyMode::System => builder,
+        OptimizerProxyMode::Disabled => builder.no_proxy(),
+    };
+    builder
+        .build()
+        .map_err(|error| format!("创建优化 HTTP 客户端失败：{error}"))
+}
+
 /// Builds the dedicated HTTP client for optimizer requests. The shared
 /// `AppState` client caps connects at 5s, which is too tight for provider
 /// relays behind a system proxy (CONNECT + TLS handshake routinely exceed
 /// that). The per-request `.timeout()` still bounds the whole call.
 pub fn optimizer_http_client() -> Result<Client, String> {
-    Client::builder()
-        .user_agent(format!("Codey/{}", env!("CARGO_PKG_VERSION")))
-        .connect_timeout(Duration::from_secs(15))
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .map_err(|error| format!("创建优化 HTTP 客户端失败：{error}"))
+    build_optimizer_http_client(Client::builder(), OptimizerProxyMode::System)
+}
+
+/// Builds an optimizer client for Codey's loopback router. Local requests must
+/// never inherit the Windows system proxy, even when its bypass list is broken.
+pub fn loopback_optimizer_http_client() -> Result<Client, String> {
+    build_optimizer_http_client(Client::builder(), OptimizerProxyMode::Disabled)
 }
 
 fn request_endpoint(
@@ -1037,6 +1061,108 @@ mod tests {
 
     use super::*;
 
+    #[tokio::test]
+    async fn loopback_optimizer_client_bypasses_configured_proxy() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        use tokio::time::timeout;
+
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_address = target.local_addr().unwrap();
+        let target_server = tokio::spawn(async move {
+            let (mut socket, _) = target.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-length: 6\r\nconnection: close\r\n\r\ntarget",
+                )
+                .await
+                .unwrap();
+        });
+
+        let proxy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_address = proxy.local_addr().unwrap();
+        let proxy_server = tokio::spawn(async move {
+            let Ok(Ok((mut socket, _))) = timeout(Duration::from_millis(500), proxy.accept()).await
+            else {
+                return false;
+            };
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 502 Bad Gateway\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            true
+        });
+
+        let client = build_optimizer_http_client(
+            Client::builder().proxy(
+                reqwest::Proxy::all(format!("http://{proxy_address}"))
+                    .expect("test proxy URL is valid"),
+            ),
+            OptimizerProxyMode::Disabled,
+        )
+        .unwrap();
+        let response = client
+            .get(format!("http://{target_address}/health"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.text().await.unwrap(), "target");
+        target_server.await.unwrap();
+        assert!(
+            !proxy_server.await.unwrap(),
+            "loopback request used the proxy"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_optimizer_client_preserves_configured_proxy() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let proxy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_address = proxy.local_addr().unwrap();
+        let proxy_server = tokio::spawn(async move {
+            let (mut socket, _) = proxy.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let bytes_read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..bytes_read]);
+            assert!(
+                request.starts_with("GET http://example.invalid/health HTTP/1.1"),
+                "{request}"
+            );
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-length: 5\r\nconnection: close\r\n\r\nproxy",
+                )
+                .await
+                .unwrap();
+        });
+
+        let client = build_optimizer_http_client(
+            Client::builder().proxy(
+                reqwest::Proxy::all(format!("http://{proxy_address}"))
+                    .expect("test proxy URL is valid"),
+            ),
+            OptimizerProxyMode::System,
+        )
+        .unwrap();
+        let response = client
+            .get("http://example.invalid/health")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.text().await.unwrap(), "proxy");
+        proxy_server.await.unwrap();
+    }
+
     fn configured() -> PromptOptimizationConfig {
         PromptOptimizationConfig {
             enabled: true,
@@ -1046,6 +1172,10 @@ mod tests {
             model: "gpt-test".to_string(),
             ..PromptOptimizationConfig::default()
         }
+    }
+
+    fn test_client() -> Client {
+        Client::builder().no_proxy().build().unwrap()
     }
 
     #[test]
@@ -1273,7 +1403,7 @@ mod tests {
 
         let mut config = configured();
         config.base_url = format!("http://{address}");
-        let client = Client::new();
+        let client = test_client();
         let models = fetch_models(&client, &config).await.unwrap();
         assert_eq!(models, ["model-a", "model-b"]);
         server.await.unwrap();
@@ -1310,7 +1440,7 @@ mod tests {
 
         let mut config = configured();
         config.base_url = format!("http://{address}");
-        let models = fetch_models(&Client::new(), &config).await.unwrap();
+        let models = fetch_models(&test_client(), &config).await.unwrap();
         assert_eq!(models, ["fallback-model"]);
         server.await.unwrap();
     }
@@ -1337,7 +1467,7 @@ mod tests {
 
         let mut config = configured();
         config.base_url = format!("http://{address}/v1");
-        let error = test_configuration(&Client::new(), &config)
+        let error = test_configuration(&test_client(), &config)
             .await
             .unwrap_err();
         assert!(error.contains("401"), "{error}");
@@ -1374,7 +1504,7 @@ mod tests {
 
         let mut config = configured();
         config.base_url = format!("http://{address}");
-        let error = test_configuration(&Client::new(), &config)
+        let error = test_configuration(&test_client(), &config)
             .await
             .unwrap_err();
         assert!(error.contains("401"), "{error}");
@@ -1406,7 +1536,7 @@ mod tests {
 
         let mut config = configured();
         config.base_url = format!("http://{address}/v1");
-        let error = test_configuration(&Client::new(), &config)
+        let error = test_configuration(&test_client(), &config)
             .await
             .unwrap_err();
         assert!(error.contains("过大"), "{error}");
@@ -1653,7 +1783,7 @@ mod tests {
 
     #[tokio::test]
     async fn optimize_prompt_validates_before_any_request() {
-        let client = Client::new();
+        let client = test_client();
         let config = configured();
 
         assert!(
@@ -1747,7 +1877,7 @@ mod tests {
 
         let mut config = configured();
         config.base_url = format!("http://{address}");
-        let client = Client::new();
+        let client = test_client();
         let result = optimize_prompt(&client, &config, "写个博客").await.unwrap();
         assert_eq!(result, "优化后的提示词");
         server.await.unwrap();
@@ -1840,7 +1970,7 @@ mod tests {
             upstream_protocol: UPSTREAM_PROTOCOL_OPENAI_RESPONSES.to_string(),
             instruction: "保持原意".to_string(),
         };
-        let result = optimize_prompt_resolved(&Client::new(), &config, "写个博客")
+        let result = optimize_prompt_resolved(&test_client(), &config, "写个博客")
             .await
             .unwrap();
         assert_eq!(result, "优化后的响应");
@@ -1931,7 +2061,7 @@ mod tests {
             upstream_protocol: UPSTREAM_PROTOCOL_OPENAI_RESPONSES.to_string(),
             instruction: "保持原意".to_string(),
         };
-        let result = optimize_prompt_resolved(&Client::new(), &config, "写个博客")
+        let result = optimize_prompt_resolved(&test_client(), &config, "写个博客")
             .await
             .unwrap();
         assert_eq!(result, "官方优化");
@@ -1960,7 +2090,7 @@ mod tests {
 
         let mut config = configured();
         config.base_url = format!("http://{address}");
-        let client = Client::new();
+        let client = test_client();
         let error = optimize_prompt(&client, &config, "你好").await.unwrap_err();
         assert!(error.contains("401"), "{error}");
         assert!(!error.contains("sk-test-key"), "{error}");


### PR DESCRIPTION
## Problem

When local routing is enabled, Codex app-server requests to Codey's `127.0.0.1` listener can still inherit the Windows system proxy. A proxy that does not bypass loopback then intercepts the request, so direct Codex conversations fail even though Codey's local router is running. Prompt optimization through `codeyRoute` can hit the same problem.

There is also a startup race: when the Inspector patch succeeds first, the launcher drops the CLI wrapper handshake listener. A wrapper that starts shortly afterward keeps retrying that closed port and records a misleading `compatibility_fallback` timeout even though the wrapper executed successfully.

## Changes

- Merge `127.0.0.1`, `localhost`, and `::1` into the managed Codex CLI `NO_PROXY` environment only while `model_provider=codey_router` is active, preserving existing bypass entries.
- Keep local routing disabled behavior unchanged, so Codex continues to inherit the user's normal proxy configuration.
- Use a dedicated no-proxy HTTP client for prompt optimization requests that target Codey's loopback route. Remote optimization requests continue to use the system proxy.
- Make the CLI wrapper handshake marker-only when an Inspector-capable launch can win the readiness race. CLI-only fallback launches keep the authenticated TCP handshake, and the internal control variable is removed before starting the real Codex CLI.
- Add regression coverage for proxy selection, loopback bypass merging, and marker-only wrapper readiness.

The resulting routing behavior is:

| Mode | Codex to Codey loopback | Codey to model provider |
| --- | --- | --- |
| Local router enabled | Bypass system proxy | Keep system proxy |
| Local router disabled | Inherit normal proxy behavior | Inherit normal proxy behavior |

## Validation

- `cargo test -p codey --lib cli_wrapper --locked` — 21 passed
- `cargo test -p codey --lib prompt_optimization --locked` — 37 passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `pnpm run check`
- Windows release build and NSIS packaging completed successfully
