### PR TITLE
fix(router): normalize cross-provider response history

### DIFF
--- a/backend/src/local_router/compaction.rs
+++ b/backend/src/local_router/compaction.rs
@@ -44,10 +44,17 @@ pub(crate) fn validate_portable_context(body: &Value) -> Result<()> {
 
 pub(crate) fn validate_cross_route_context(body: &Value) -> Result<()> {
     validate_portable_context(body)?;
-    if input_items(body)
-        .iter()
-        .any(|item| item.get("type").and_then(Value::as_str) == Some("item_reference"))
-    {
+    fn contains_item_reference(value: &Value) -> bool {
+        if value.get("type").and_then(Value::as_str) == Some("item_reference") {
+            return true;
+        }
+        match value {
+            Value::Array(items) => items.iter().any(contains_item_reference),
+            Value::Object(object) => object.values().any(contains_item_reference),
+            _ => false,
+        }
+    }
+    if input_items(body).iter().any(contains_item_reference) {
         anyhow::bail!("context_not_portable: item_reference 属于上一条线路，不能发送到新的供应商");
     }
     Ok(())
@@ -254,6 +261,17 @@ mod tests {
         assert!(normalize_native_responses_context(&mut single, false));
         assert_eq!(single["input"]["id"], "rs_single");
         assert!(single["input"].get("content").is_none());
+    }
+
+    #[test]
+    fn cross_route_context_rejects_nested_item_reference() {
+        let body = json!({
+            "input": [{
+                "role": "assistant",
+                "content": [{"type": "output_text", "annotations": [{"type": "item_reference"}]}]
+            }]
+        });
+        assert!(validate_cross_route_context(&body).is_err());
     }
 
     #[test]

--- a/backend/src/local_router/compaction.rs
+++ b/backend/src/local_router/compaction.rs
@@ -42,6 +42,73 @@ pub(crate) fn validate_portable_context(body: &Value) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn validate_cross_route_context(body: &Value) -> Result<()> {
+    validate_portable_context(body)?;
+    if input_items(body)
+        .iter()
+        .any(|item| item.get("type").and_then(Value::as_str) == Some("item_reference"))
+    {
+        anyhow::bail!("context_not_portable: item_reference 属于上一条线路，不能发送到新的供应商");
+    }
+    Ok(())
+}
+
+pub(crate) fn normalize_native_responses_context(
+    body: &mut Value,
+    discard_opaque_reasoning: bool,
+) -> bool {
+    fn normalize_reasoning_item(item: &mut Value, discard_opaque_reasoning: bool) -> (bool, bool) {
+        if item.get("type").and_then(Value::as_str) != Some("reasoning") {
+            return (true, false);
+        }
+        if discard_opaque_reasoning {
+            return (false, true);
+        }
+        let has_nonempty_content = item
+            .get("content")
+            .and_then(Value::as_array)
+            .is_some_and(|content| !content.is_empty());
+        if !has_nonempty_content {
+            return (true, false);
+        }
+        let has_encrypted_content = item
+            .get("encrypted_content")
+            .and_then(Value::as_str)
+            .is_some_and(|content| !content.trim().is_empty());
+        if has_encrypted_content {
+            item.as_object_mut()
+                .expect("reasoning input item must remain an object")
+                .remove("content");
+            (true, true)
+        } else {
+            (false, true)
+        }
+    }
+
+    let Some(input) = body.get_mut("input") else {
+        return false;
+    };
+    match input {
+        Value::Array(items) => {
+            let mut mutated = false;
+            items.retain_mut(|item| {
+                let (keep, item_mutated) = normalize_reasoning_item(item, discard_opaque_reasoning);
+                mutated |= item_mutated;
+                keep
+            });
+            mutated
+        }
+        Value::Object(_) => {
+            let (keep, mutated) = normalize_reasoning_item(input, discard_opaque_reasoning);
+            if !keep {
+                *input = Value::Array(Vec::new());
+            }
+            mutated
+        }
+        _ => false,
+    }
+}
+
 // Only in-flight work is owned here. Codex remains responsible for history
 // versions, retries and installing a successful compaction result.
 pub(crate) struct CompactionGuard {
@@ -154,6 +221,40 @@ pub(crate) fn validate_compaction_result(value: &Value, v2: bool) -> Result<()> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn native_reasoning_normalization_preserves_same_provider_encrypted_state() {
+        let mut body = json!({
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_encrypted",
+                    "encrypted_content": "opaque-state",
+                    "content": [{"type": "reasoning_text", "text": "private"}]
+                },
+                {"role": "user", "content": "continue"}
+            ]
+        });
+
+        assert!(normalize_native_responses_context(&mut body, false));
+        assert_eq!(body["input"].as_array().unwrap().len(), 2);
+        assert_eq!(body["input"][0]["id"], "rs_encrypted");
+        assert_eq!(body["input"][0]["encrypted_content"], "opaque-state");
+        assert!(body["input"][0].get("content").is_none());
+        assert_eq!(body["input"][1]["role"], "user");
+
+        let mut single = json!({
+            "input": {
+                "type": "reasoning",
+                "id": "rs_single",
+                "encrypted_content": "opaque-single",
+                "content": [{"type": "reasoning_text", "text": "private"}]
+            }
+        });
+        assert!(normalize_native_responses_context(&mut single, false));
+        assert_eq!(single["input"]["id"], "rs_single");
+        assert!(single["input"].get("content").is_none());
+    }
 
     #[test]
     fn compaction_guard_releases_on_failure_and_serializes_overlapping_sessions() {

--- a/backend/src/local_router/downstream.rs
+++ b/backend/src/local_router/downstream.rs
@@ -72,6 +72,7 @@ pub(crate) trait ResponsesDownstream: Send {
         _route: &RouteTarget,
         _headers: &HeaderMap,
         _body: &mut Value,
+        _discard_opaque_reasoning: bool,
         _probe: Option<&RouteRequestLogProbe>,
     ) -> Result<UpstreamWebSocketAttempt> {
         Ok(UpstreamWebSocketAttempt::UseHttp)
@@ -82,9 +83,16 @@ pub(crate) trait ResponsesDownstream: Send {
         route: &RouteTarget,
         headers: &HeaderMap,
         body: &mut Value,
+        discard_opaque_reasoning: bool,
     ) -> Result<UpstreamWebSocketAttempt> {
-        self.try_proxy_upstream_websocket_with_probe(route, headers, body, None)
-            .await
+        self.try_proxy_upstream_websocket_with_probe(
+            route,
+            headers,
+            body,
+            discard_opaque_reasoning,
+            None,
+        )
+        .await
     }
 }
 
@@ -298,6 +306,7 @@ where
         route: &RouteTarget,
         headers: &HeaderMap,
         body: &mut Value,
+        discard_opaque_reasoning: bool,
         probe: Option<&RouteRequestLogProbe>,
     ) -> Result<UpstreamWebSocketAttempt> {
         let result = self
@@ -306,6 +315,7 @@ where
                 route,
                 headers,
                 body,
+                discard_opaque_reasoning,
                 probe.or(self.probe.as_ref()),
             )
             .await;

--- a/backend/src/local_router/responses.rs
+++ b/backend/src/local_router/responses.rs
@@ -1251,26 +1251,17 @@ impl RouterServer {
         body_mutated |= model_was_defaulted;
         let subagent_request = request_is_subagent(&request);
         let binding_keys = request_binding_keys(&request);
-        // Route lookup and binding refresh are both synchronous hash lookups.
-        // Keeping them under one short critical section halves mutex traffic on
-        // the request hot path without holding the lock across any I/O.
-        let resolved = {
-            let mut bindings = self
+        // Resolve against the current binding, but do not replace it until the
+        // request passes local cross-route history validation.
+        let (resolved, previous_route) = {
+            let bindings = self
                 .bindings
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let bound_route = bindings.route_for_keys(&binding_keys);
             let resolved =
                 snapshot.target_for_request(&model, route_hint.as_deref(), bound_route.as_deref());
-            if let Ok(resolved) = &resolved {
-                let refresh_session_binding = route_hint.is_some() && !subagent_request;
-                bindings.remember(
-                    &binding_keys,
-                    &resolved.provider_id,
-                    refresh_session_binding,
-                );
-            }
-            resolved
+            (resolved, bound_route)
         };
         let resolved = match resolved {
             Ok(resolved) => resolved,
@@ -1281,6 +1272,9 @@ impl RouterServer {
                 return Ok(());
             }
         };
+        let route_changed = previous_route
+            .as_deref()
+            .is_some_and(|provider_id| provider_id != resolved.provider_id);
         if model != resolved.upstream_model {
             body.as_object_mut()
                 .expect("validated Responses body must remain an object")
@@ -1388,6 +1382,25 @@ impl RouterServer {
             // JSON slice, which would contain only the latest delta.
             encoded_body = None;
         }
+        if bridge == ProtocolBridge::NativeResponses
+            && route_changed
+            && let Err(error) = validate_cross_route_context(&body)
+        {
+            return downstream
+                .write_error(
+                    400,
+                    "context_not_portable",
+                    error.to_string(),
+                    Some(&resolved.route),
+                )
+                .await;
+        }
+        if bridge == ProtocolBridge::NativeResponses
+            && normalize_native_responses_context(&mut body, route_changed)
+        {
+            body_mutated = true;
+            encoded_body = None;
+        }
         let force_upstream_stream = should_force_upstream_streaming(
             bridge,
             request_kind,
@@ -1491,6 +1504,20 @@ impl RouterServer {
                 return Ok(());
             }
         };
+        // Commit the new binding only after the request's route compatibility,
+        // payload conversion, and credentials have passed local checks. A
+        // rejected switch must leave the prior route available for a retry.
+        {
+            let refresh_session_binding = route_hint.is_some() && !subagent_request;
+            self.bindings
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remember(
+                    &binding_keys,
+                    &resolved.provider_id,
+                    refresh_session_binding,
+                );
+        }
         if bridge == ProtocolBridge::NativeResponses {
             ensure_native_prompt_cache_key(
                 &mut headers,
@@ -1512,7 +1539,12 @@ impl RouterServer {
                 let had_previous_response =
                     responses_previous_response_id(&upstream_body).is_some();
                 let websocket_attempt = downstream
-                    .try_proxy_upstream_websocket(&resolved.route, &headers, &mut upstream_body)
+                    .try_proxy_upstream_websocket(
+                        &resolved.route,
+                        &headers,
+                        &mut upstream_body,
+                        route_changed,
+                    )
                     .await?;
                 if websocket_attempt == UpstreamWebSocketAttempt::Completed {
                     return Ok(());
@@ -1555,6 +1587,23 @@ impl RouterServer {
                         )
                         .await;
                 }
+            }
+            // A failed/reconnected WebSocket can restore full history after the
+            // first normalization pass. Validate and normalize the exact body
+            // that will be sent through the HTTP fallback as well.
+            if route_changed && let Err(error) = validate_cross_route_context(&upstream_body) {
+                return downstream
+                    .write_error(
+                        400,
+                        "context_not_portable",
+                        error.to_string(),
+                        Some(&resolved.route),
+                    )
+                    .await;
+            }
+            if normalize_native_responses_context(&mut upstream_body, route_changed) {
+                body_mutated = true;
+                encoded_body = None;
             }
         }
         let upstream_stream_requested = upstream_body

--- a/backend/src/local_router/tests.rs
+++ b/backend/src/local_router/tests.rs
@@ -674,7 +674,7 @@ async fn upstream_websocket_normalizes_sse_wrapped_events_to_json_frames() {
 
     assert_eq!(
         downstream
-            .proxy_upstream_websocket(&route, &HeaderMap::new(), &mut body, None)
+            .proxy_upstream_websocket(&route, &HeaderMap::new(), &mut body, false, None)
             .await
             .unwrap(),
         UpstreamWebSocketAttempt::Completed
@@ -1493,7 +1493,7 @@ async fn upstream_websocket_reconnects_when_account_identity_changes() {
         let mut body = json!({"model":model,"input":input});
         assert_eq!(
             downstream
-                .proxy_upstream_websocket(&route, &headers, &mut body, None)
+                .proxy_upstream_websocket(&route, &headers, &mut body, false, None)
                 .await
                 .unwrap(),
             UpstreamWebSocketAttempt::Completed
@@ -1594,7 +1594,7 @@ async fn upstream_websocket_keeps_continuation_on_original_account_connection() 
         }
         assert_eq!(
             downstream
-                .proxy_upstream_websocket(&route, &headers, &mut body, None)
+                .proxy_upstream_websocket(&route, &headers, &mut body, false, None)
                 .await
                 .unwrap(),
             UpstreamWebSocketAttempt::Completed
@@ -1666,7 +1666,7 @@ async fn unknown_previous_response_id_uses_http_fallback_instead_of_websocket_re
     let mut first_body = json!({"model":model,"input":"first"});
     assert_eq!(
         downstream
-            .proxy_upstream_websocket(&route, &headers, &mut first_body, None)
+            .proxy_upstream_websocket(&route, &headers, &mut first_body, false, None)
             .await
             .unwrap(),
         UpstreamWebSocketAttempt::Completed
@@ -1681,7 +1681,13 @@ async fn unknown_previous_response_id_uses_http_fallback_instead_of_websocket_re
     });
     assert_eq!(
         downstream
-            .proxy_upstream_websocket(&route, &headers, &mut continuation_from_elsewhere, None,)
+            .proxy_upstream_websocket(
+                &route,
+                &headers,
+                &mut continuation_from_elsewhere,
+                false,
+                None,
+            )
             .await
             .unwrap(),
         UpstreamWebSocketAttempt::UseHttp
@@ -6283,7 +6289,11 @@ async fn model_switch_from_chat_to_native_expands_synthetic_history_in_order() {
     let upstream_task = tokio::spawn(async move {
         let (mut first, _) = upstream.accept().await.unwrap();
         read_http_request(&mut first).await.unwrap();
-        let sse = "data: {\"id\":\"chat-first\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"remembered answer\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n";
+        let sse = concat!(
+            "data: {\"id\":\"chat-first\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"private bridge reasoning\"}}]}\n\n",
+            "data: {\"id\":\"chat-first\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"remembered answer\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
         first.write_all(format!("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{sse}", sse.len()).as_bytes()).await.unwrap();
         let (mut second, _) = upstream.accept().await.unwrap();
         let request = read_http_request(&mut second).await.unwrap();
@@ -6328,8 +6338,191 @@ async fn model_switch_from_chat_to_native_expands_synthetic_history_in_order() {
     assert_eq!(sent["input"][1]["role"], "assistant");
     assert_eq!(sent["input"][1]["content"][0]["text"], "remembered answer");
     assert_eq!(sent["input"][2], "continue");
+    assert!(
+        sent["input"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| { item.get("type").and_then(Value::as_str) != Some("reasoning") })
+    );
     socket.close(None).await.unwrap();
     router.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn native_route_switch_drops_previous_provider_reasoning_state() {
+    let upstream = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let upstream_address = upstream.local_addr().unwrap();
+    let (mut config, provider_a, model) = router_config(format!("http://{upstream_address}/v1"));
+    let mut route_b = config.profiles[0].clone();
+    route_b.id = "route-native-b".into();
+    route_b.name = "Native B".into();
+    route_b.normalize();
+    let provider_b = route_b.provider_id().to_string();
+    config.profiles.push(route_b);
+    config
+        .selected_models_by_provider
+        .insert(provider_b.clone(), vec![model.clone()]);
+    let upstream_task = tokio::spawn(async move {
+        let mut bodies = Vec::new();
+        for _ in 0..2 {
+            let (mut stream, _) = upstream.accept().await.unwrap();
+            let request = read_http_request(&mut stream).await.unwrap();
+            let body = serde_json::from_slice::<Value>(&request.body).unwrap();
+            write_json_response(
+                &mut stream,
+                200,
+                &json!({"id":"resp-native","object":"response","model":body["model"],"output":[]}),
+            )
+            .await
+            .unwrap();
+            bodies.push(body);
+        }
+        bodies
+    });
+    let router = LocalRouter::start(&config).await.unwrap();
+    let endpoint = router.endpoint();
+    let client = reqwest::Client::new();
+
+    let first = client
+        .post(format!("{}/responses", endpoint.base_url))
+        .bearer_auth(&endpoint.token)
+        .header("thread-id", "native-provider-switch")
+        .json(&json!({"model":model_alias(&provider_a, &model),"input":"first"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+
+    let second = client
+        .post(format!("{}/responses", endpoint.base_url))
+        .bearer_auth(&endpoint.token)
+        .header("thread-id", "native-provider-switch")
+        .json(&json!({
+            "model":model_alias(&provider_b, &model),
+            "input":[
+                {"role":"user","content":"original task"},
+                {"type":"reasoning","id":"rs_provider_a","encrypted_content":"opaque-provider-a"},
+                {"role":"assistant","content":[{"type":"output_text","text":"visible answer"}]},
+                {"role":"user","content":"continue"}
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.status(), reqwest::StatusCode::OK);
+
+    let bodies = upstream_task.await.unwrap();
+    assert_eq!(bodies[1]["input"].as_array().unwrap().len(), 3);
+    assert!(
+        bodies[1]["input"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| { item.get("type").and_then(Value::as_str) != Some("reasoning") })
+    );
+    assert_eq!(bodies[1]["input"][1]["role"], "assistant");
+    assert_eq!(
+        bodies[1]["input"][1]["content"][0]["text"],
+        "visible answer"
+    );
+    router.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn native_route_switch_rejects_provider_bound_history_references_locally() {
+    for opaque_item in [
+        json!({"type":"compaction","id":"cmp_provider_a","encrypted_content":"opaque-provider-a"}),
+        json!({"type":"item_reference","id":"item_provider_a"}),
+    ] {
+        let upstream = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let upstream_address = upstream.local_addr().unwrap();
+        let (mut config, provider_a, model) =
+            router_config(format!("http://{upstream_address}/v1"));
+        let mut route_b = config.profiles[0].clone();
+        route_b.id = "route-native-b".into();
+        route_b.name = "Native B".into();
+        route_b.normalize();
+        let provider_b = route_b.provider_id().to_string();
+        config.profiles.push(route_b);
+        config
+            .selected_models_by_provider
+            .insert(provider_b.clone(), vec![model.clone()]);
+        let upstream_task = tokio::spawn(async move {
+            let (mut first, _) = upstream.accept().await.unwrap();
+            let request = read_http_request(&mut first).await.unwrap();
+            let body = serde_json::from_slice::<Value>(&request.body).unwrap();
+            write_json_response(
+                &mut first,
+                200,
+                &json!({"id":"resp-native","object":"response","model":body["model"],"output":[]}),
+            )
+            .await
+            .unwrap();
+            if let Ok(Ok((mut second, _))) =
+                tokio::time::timeout(Duration::from_millis(250), upstream.accept()).await
+            {
+                let _request = read_http_request(&mut second).await.unwrap();
+                write_json_response(
+                    &mut second,
+                    200,
+                    &json!({"id":"unexpected-forward","object":"response","output":[]}),
+                )
+                .await
+                .unwrap();
+                return true;
+            }
+            false
+        });
+        let router = LocalRouter::start(&config).await.unwrap();
+        let endpoint = router.endpoint();
+        let client = reqwest::Client::new();
+
+        let first = client
+            .post(format!("{}/responses", endpoint.base_url))
+            .bearer_auth(&endpoint.token)
+            .header("thread-id", "native-provider-reference-switch")
+            .json(&json!({"model":model_alias(&provider_a, &model),"input":"first"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(first.status(), reqwest::StatusCode::OK);
+
+        let second = client
+            .post(format!("{}/responses", endpoint.base_url))
+            .bearer_auth(&endpoint.token)
+            .header("thread-id", "native-provider-reference-switch")
+            .json(&json!({
+                "model":model_alias(&provider_b, &model),
+                "input":[{"role":"user","content":"continue"},opaque_item.clone()]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(second.status().as_u16(), 400);
+        assert_eq!(
+            second.json::<Value>().await.unwrap()["error"]["code"],
+            "context_not_portable"
+        );
+        let retry = client
+            .post(format!("{}/responses", endpoint.base_url))
+            .bearer_auth(&endpoint.token)
+            .header("thread-id", "native-provider-reference-switch")
+            .json(&json!({
+                "model":model_alias(&provider_b, &model),
+                "input":[{"role":"user","content":"continue"},opaque_item]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(retry.status().as_u16(), 400);
+        assert_eq!(
+            retry.json::<Value>().await.unwrap()["error"]["code"],
+            "context_not_portable"
+        );
+        assert!(!upstream_task.await.unwrap());
+        router.stop().await.unwrap();
+    }
 }
 
 #[tokio::test]

--- a/backend/src/local_router/websocket.rs
+++ b/backend/src/local_router/websocket.rs
@@ -243,6 +243,7 @@ impl WebSocketResponsesDownstream {
         route: &RouteTarget,
         headers: &HeaderMap,
         body: &mut Value,
+        discard_opaque_reasoning: bool,
         probe: Option<&RouteRequestLogProbe>,
     ) -> Result<UpstreamWebSocketAttempt> {
         if !route.supports_websockets {
@@ -306,6 +307,7 @@ impl WebSocketResponsesDownstream {
             }
             self.upstream.take();
         }
+        normalize_native_responses_context(body, discard_opaque_reasoning);
         let mut upstream = if let Some(cached) = self.upstream.take() {
             cached
         } else {
@@ -980,9 +982,10 @@ impl ResponsesDownstream for WebSocketResponsesDownstream {
         route: &RouteTarget,
         headers: &HeaderMap,
         body: &mut Value,
+        discard_opaque_reasoning: bool,
         probe: Option<&RouteRequestLogProbe>,
     ) -> Result<UpstreamWebSocketAttempt> {
-        self.proxy_upstream_websocket(route, headers, body, probe)
+        self.proxy_upstream_websocket(route, headers, body, discard_opaque_reasoning, probe)
             .await
     }
 }


### PR DESCRIPTION
## Problem

Switching models across different routes within the same Codex conversation can replay provider-specific Responses history to the newly selected provider.

A reproduced sequence is:

1. Start a conversation on the official OpenAI route with `gpt-5.6-sol`.
2. In the same conversation, switch to a Chat-compatible third-party route such as `glm-5.3` and send a message.
3. Switch back to the official OpenAI route and send another message.
4. The request can fail with HTTP 400:

```
Invalid input[29].content: array too long.
Expected an array with maximum length 0, but got an array with length 1 instead.
code: array_above_max_length
```

## Root cause

Chat-compatible adapters can emit a synthetic top-level Responses `reasoning` item whose `content` array contains reasoning text. When the route changes, the expanded conversation history could be passed through as raw JSON to a native Responses provider. OpenAI accepts no content entries on that input reasoning item, so the replayed provider-specific state is rejected.

Other opaque history items, including encrypted reasoning, compaction snapshots, and item references, are also bound to the provider or route that created them and are not generally portable.

## Fix

- Normalize native Responses history by input shape instead of checking specific model names.
- Remove synthetic reasoning items that have no encrypted provider state.
- Preserve same-provider encrypted reasoning while removing incompatible non-empty `content`.
- Drop opaque reasoning when the provider changes.
- Reject cross-route `compaction` and `item_reference` history locally with `context_not_portable`.
- Delay route binding updates until local compatibility and conversion checks pass.
- Apply the same normalization to native WebSocket history restoration and HTTP fallback.
- Preserve visible user and assistant messages and existing tool-call behavior.

## Verification

- Reproduced the failure by switching routes in one conversation and confirmed the fixed build continues successfully.
- `cargo test -p codey --lib`
  - 1121 passed
  - 0 failed
  - 4 ignored
- `cargo fmt --all -- --check`
- `git diff --check upstream/master...HEAD`