### PR TITLE
fix: restore Windows startup and bind ambiguous models

### DIFF
--- a/backend/src/codex_provider.rs
+++ b/backend/src/codex_provider.rs
@@ -13,6 +13,7 @@ use codey_runtime_core::app_paths::{codex_runtime_executable, resolve_codex_app_
 use codey_runtime_core::config_manager::ConfigManager;
 use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use toml_edit::{DocumentMut, Item, TableLike};
 
 use crate::codex_config::BUILTIN_OPENAI_PROVIDER_ID;
@@ -265,7 +266,10 @@ fn sync_provider_profile(
         next.upstream_models_by_provider
             .remove(&placeholder_provider_id);
     } else if let Some(existing) = next.profiles.iter_mut().find(|existing| {
-        existing.provider_id() == imported_provider_id || existing.id == imported_id
+        (existing.id == imported_id && existing.normalized_base_url() == provider.base_url)
+            || (existing.official_account == provider.official
+                && existing.provider_id() == imported_provider_id
+                && existing.normalized_base_url() == provider.base_url)
     }) {
         // Keep the Codey UI identity stable when a previously imported route
         // has a different runtime provider id.
@@ -279,7 +283,19 @@ fn sync_provider_profile(
         }
         *existing = replacement;
     } else {
-        next.profiles.push(profile);
+        if next
+            .profiles
+            .iter()
+            .any(|existing| existing.id == profile.id)
+        {
+            let mut profile = profile;
+            profile.id = unique_imported_route_id(&next.profiles, &provider, upstream_protocol);
+            profile.source_provider_id = Some(provider.id.clone());
+            active_profile_id = profile.id.clone();
+            next.profiles.push(profile);
+        } else {
+            next.profiles.push(profile);
+        }
     }
     next.active_profile_id = active_profile_id;
     next.initial_route_import_completed = true;
@@ -290,6 +306,37 @@ fn sync_provider_profile(
         next.settings_revision = config.settings_revision.saturating_add(1);
     }
     Ok((next, ProviderStatus { changed, provider }))
+}
+
+fn stable_imported_route_id(provider: &CurrentProvider, upstream_protocol: &str) -> String {
+    let identity = format!(
+        "{}\n{}\n{}",
+        provider.id, provider.base_url, upstream_protocol
+    );
+    let digest = Sha256::digest(identity.as_bytes());
+    let suffix = digest[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("route-{suffix}")
+}
+
+fn unique_imported_route_id(
+    profiles: &[ProviderProfile],
+    provider: &CurrentProvider,
+    upstream_protocol: &str,
+) -> String {
+    let base = stable_imported_route_id(provider, upstream_protocol);
+    if !profiles.iter().any(|profile| profile.id == base) {
+        return base;
+    }
+    for suffix in 2..=99 {
+        let candidate = format!("{base}-{suffix}");
+        if !profiles.iter().any(|profile| profile.id == candidate) {
+            return candidate;
+        }
+    }
+    format!("{base}-{}", profiles.len() + 1)
 }
 
 pub fn status_from_config(config: &CodeyConfig) -> ProviderStatus {
@@ -381,6 +428,9 @@ fn local_provider_with_auth_policy(
     let mut base_url = table
         .and_then(|provider| provider.get("base_url"))
         .and_then(Item::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| document.get("openai_base_url").and_then(Item::as_str))
         .unwrap_or_default()
         .trim()
         .trim_end_matches('/')
@@ -1498,8 +1548,56 @@ experimental_bearer_token = "sk-relay"
         )
         .unwrap();
 
+        assert_eq!(synced.profiles.len(), 2);
         assert_eq!(synced.profiles[0].short_name, "中");
-        assert_eq!(synced.profiles[0].name, "Relay Updated");
+        assert_eq!(synced.profiles[0].base_url, "https://old.example/v1");
+        assert_eq!(synced.profiles[1].name, "Relay Updated");
+        assert_eq!(synced.profiles[1].base_url, "https://new.example/v1");
+        assert_eq!(
+            synced.profiles[1].source_provider_id.as_deref(),
+            Some("relay")
+        );
+        assert_ne!(synced.profiles[0].id, synced.profiles[1].id);
+
+        let imported_id = synced.profiles[1].id.clone();
+        let (synced_again, _) = sync_provider_profile(
+            &synced,
+            CurrentProvider {
+                id: "relay".into(),
+                name: "Relay Updated".into(),
+                official: false,
+                supports_remote_compaction: false,
+                base_url: "https://new.example/v1".into(),
+            },
+            "new-key".into(),
+            crate::config::UPSTREAM_PROTOCOL_OPENAI_RESPONSES,
+        )
+        .unwrap();
+        assert_eq!(synced_again.profiles.len(), 2);
+        assert_eq!(synced_again.profiles[1].id, imported_id);
+    }
+
+    #[test]
+    fn top_level_openai_base_url_stays_paired_with_provider_key() {
+        let home = TempDir::new().unwrap();
+        write_config(
+            home.path(),
+            r#"openai_base_url = "https://relay.example/v1"
+model_provider = "openai"
+
+[model_providers.openai]
+name = "OpenAI"
+wire_api = "responses"
+experimental_bearer_token = "sk-relay"
+"#,
+        );
+        let provider = current_provider(home.path()).unwrap();
+        assert_eq!(provider.base_url, "https://relay.example/v1");
+        assert!(!provider.official);
+        let (config, _) =
+            sync_current_third_party_provider(&CodeyConfig::default(), home.path()).unwrap();
+        assert_eq!(config.profiles[0].base_url, "https://relay.example/v1");
+        assert_eq!(config.profiles[0].api_key, "sk-relay");
     }
 
     #[test]

--- a/backend/src/launcher/process.rs
+++ b/backend/src/launcher/process.rs
@@ -204,8 +204,9 @@ pub(super) async fn spawn_codex(
 
     #[cfg(windows)]
     {
-        // Prefer NODE_OPTIONS `--require` whenever that fuse is on. Inspector
-        // evaluate is the fallback. Never combine the two: both wrap Module._load.
+        // Use the established Inspector path when the Electron fuse permits it;
+        // the CLI wrapper is the fallback when the fuse is disabled or a retry
+        // is needed.
         let mut retry_without_inspector = false;
         let mut attempt = 0;
         loop {
@@ -214,23 +215,13 @@ pub(super) async fn spawn_codex(
             error_log::refresh_codex_app_version(Some(app_dir), None);
             let fuses = crate::electron_fuses::detect_electron_fuses(app_dir.to_path_buf()).await;
             let inspect_fuse = fuses.node_cli_inspect;
-            let require_wanted = fuses.node_options.node_options_possible();
-            let require_patch = prepare_startup_require_launch(
-                require_wanted,
-                patch_options,
-                runtime_config_overrides,
-                "windows",
-            )
-            .await;
-            let use_require = require_patch.is_some();
-            let use_inspector =
-                !use_require && inspect_fuse.inspector_possible() && !retry_without_inspector;
+            let cli_only = retry_without_inspector || !inspect_fuse.inspector_possible();
 
             let (wrapper, wrapper_preparation_error) = match prepare_cli_wrapper(
                 app_dir,
                 subagent_gate_active,
                 runtime_config_overrides,
-                use_inspector || use_require,
+                !cli_only,
             )
             .await
             {
@@ -245,7 +236,9 @@ pub(super) async fn spawn_codex(
                     (None, Some(error))
                 }
             };
-            let inspector_port = if use_inspector {
+            let inspector_port = if cli_only {
+                None
+            } else {
                 Some(
                     crate::codex_startup_patch::reserve_loopback_port().map_err(|error| {
                         let error = error.context("为 Codex 启动补丁选择本地调试端口失败");
@@ -260,10 +253,8 @@ pub(super) async fn spawn_codex(
                         error
                     })?,
                 )
-            } else {
-                None
             };
-            if inspector_port.is_none() && wrapper.is_none() && require_patch.is_none() {
+            if inspector_port.is_none() && wrapper.is_none() {
                 // Neither compatibility entry exists before launch: decide now
                 // instead of starting a process that would only be stopped again.
                 let error = wrapper_preparation_error
@@ -275,31 +266,27 @@ pub(super) async fn spawn_codex(
                     runtime_config_overrides,
                     subagent_gate_active,
                     format!(
-                        "启动尝试 {attempt}/2：NODE_OPTIONS 注入不可用（{}），主进程 Inspector 不可用（{}），且 CLI 兼容入口不可用：{error:#}",
-                        fuses.node_options.as_str(),
+                        "启动尝试 {attempt}/2：主进程 Inspector 已被 Electron fuse 关闭（{}），且 CLI 兼容入口不可用：{error:#}",
                         inspect_fuse.as_str()
                     ),
                 )
                 .await;
             }
             let launch_arguments = startup_launch_arguments(&runtime_arguments, inspector_port);
-            let mut launch_environment = require_patch
+            let wrapper_environment = wrapper
                 .as_ref()
-                .map(|prepared| prepared.environment.clone())
+                .map(|wrapper| wrapper.environment.as_slice())
                 .unwrap_or_default();
-            if let Some(wrapper) = &wrapper {
-                launch_environment.extend(wrapper.environment.iter().cloned());
-            }
-            // `--require` always needs the merged launch environment. Without
-            // Inspector the wrapper is otherwise the only entry, so a constrained
-            // launch must not proceed unless Store accepts it.
+            // Without an Inspector the wrapper is the only entry, so a launch
+            // that carries runtime constraints must not proceed unless Store
+            // accepts the wrapper environment; an unconstrained launch may.
             let constrained = !runtime_config_overrides.is_empty() || subagent_gate_active;
             let launch = spawn_windows_codex(
                 app_dir,
                 debug_port,
                 &launch_arguments,
-                &launch_environment,
-                use_require || (!use_inspector && constrained),
+                wrapper_environment,
+                cli_only && constrained,
             )
             .await;
             let (mut spawned, package_debug_session, wrapper_environment_applied) = match launch {
@@ -329,11 +316,8 @@ pub(super) async fn spawn_codex(
                 "launcher.windows_startup_attempt",
                 serde_json::json!({
                     "attempt": attempt,
-                    "useInspector": use_inspector,
-                    "useRequire": use_require,
+                    "cliOnly": cli_only,
                     "inspectorFuse": inspect_fuse.as_str(),
-                    "nodeOptionsFuse": fuses.node_options.as_str(),
-                    "requirePrepared": require_patch.is_some(),
                     "processId": spawned.process_id,
                     "wrapperEnvironmentApplied": wrapper_environment_applied,
                 }),
@@ -342,11 +326,7 @@ pub(super) async fn spawn_codex(
                 .then_some(wrapper)
                 .flatten()
                 .map(CliWrapperLaunch::into_handshake);
-            let require_marker = wrapper_environment_applied
-                .then_some(require_patch)
-                .flatten()
-                .map(|prepared| prepared.marker_path);
-            if inspector_port.is_none() && wrapper_handshake.is_none() && require_marker.is_none() {
+            if inspector_port.is_none() && wrapper_handshake.is_none() {
                 // The process is already running without any compatibility
                 // entry. It carries no constraints (see above), so keep it
                 // instead of stopping and relaunching the same configuration.
@@ -356,9 +336,8 @@ pub(super) async fn spawn_codex(
                         .context("Windows Store Codex 兼容环境清理失败")?;
                 }
                 let startup_error = format!(
-                    "启动尝试 {attempt}/2：未能应用主进程注入环境（Inspector {}，NODE_OPTIONS {}），且 Windows 未能应用 CLI 兼容环境，详见启动错误日志",
+                    "启动尝试 {attempt}/2：未能应用主进程注入环境（Inspector {}），且 Windows 未能应用 CLI 兼容环境，详见启动错误日志",
                     inspect_fuse.as_str(),
-                    fuses.node_options.as_str()
                 );
                 spawned.performance_status = "degraded".to_string();
                 spawned.performance_detail =
@@ -385,7 +364,7 @@ pub(super) async fn spawn_codex(
                     deadline,
                     renderer_debug_port: Some(debug_port),
                     spawned: Some(&mut spawned),
-                    require_marker,
+                    require_marker: None,
                 },
             )
             .await
@@ -432,12 +411,10 @@ pub(super) async fn spawn_codex(
                             "platform": "windows",
                             "inspectorPort": inspector_port,
                             "inspectorFuse": inspect_fuse.as_str(),
-                            "nodeOptionsFuse": fuses.node_options.as_str(),
                             "processId": spawned.process_id,
                             "startupAttempt": attempt,
                             "processes": windows_startup_process_details(app_dir, spawned.process_id),
-                            "useInspector": use_inspector,
-                            "useRequire": use_require,
+                            "cliOnly": cli_only,
                             "retryable": retryable,
                             "remainingBudgetMs": deadline.saturating_duration_since(tokio::time::Instant::now()).as_millis(),
                             "disablePet": patch_options.disable_pet,

--- a/backend/src/local_router/server.rs
+++ b/backend/src/local_router/server.rs
@@ -599,6 +599,7 @@ pub(crate) struct RouterSnapshot {
     pub(crate) model_alias_history: BTreeMap<String, String>,
     pub(crate) model_ids: Vec<String>,
     pub(crate) default_model: String,
+    pub(crate) active_provider_id: String,
     pub(crate) request_log_backend: RouteRequestLogBackend,
     pub(crate) request_log_catalog: RequestLogCatalog,
 }
@@ -682,6 +683,7 @@ impl RouterSnapshot {
             model_alias_history: config.model_alias_history.clone(),
             model_ids,
             default_model: config.default_model().unwrap_or_default().to_string(),
+            active_provider_id: config.current_provider_id().unwrap_or_default().to_string(),
             request_log_backend: config.route_request_log.backend,
             request_log_catalog: RequestLogCatalog::from_config(config),
         }
@@ -773,6 +775,18 @@ impl RouterSnapshot {
                 .find(|candidate| candidate.provider_id == route_hint)
         {
             return self.target_for_route_model(route_hint, &candidate.model, requested_model);
+        }
+        if let Some(active_provider_id) =
+            (!self.active_provider_id.is_empty()).then_some(self.active_provider_id.as_str())
+            && let Some(candidate) = candidates
+                .iter()
+                .find(|candidate| candidate.provider_id == active_provider_id)
+        {
+            return self.target_for_route_model(
+                active_provider_id,
+                &candidate.model,
+                requested_model,
+            );
         }
         // Raw ids in the mixed runtime catalog are native OpenAI entries;
         // third-party selections remain route-qualified. An explicit hint

--- a/backend/src/local_router/tests.rs
+++ b/backend/src/local_router/tests.rs
@@ -2199,6 +2199,26 @@ fn router_snapshot_maps_route_aliases_to_upstream_models() {
 }
 
 #[test]
+fn raw_model_without_route_metadata_prefers_the_active_route() {
+    let (mut config, active_provider_id, model) =
+        router_config("https://relay-a.example/v1".into());
+    let mut second = ProviderProfile::new("Relay B");
+    second.id = "route-b".into();
+    second.base_url = "https://relay-b.example/v1".into();
+    second.api_key = "sk-second".into();
+    second.normalize();
+    config.profiles.push(second);
+    config
+        .selected_models_by_provider
+        .insert("route-b".into(), vec![model.clone()]);
+    let snapshot = RouterSnapshot::from_config(&config.normalize());
+
+    let resolved = snapshot.target_for_model(&model).unwrap();
+    assert_eq!(resolved.provider_id, active_provider_id);
+    assert_eq!(resolved.upstream_model, model);
+}
+
+#[test]
 fn historical_aliases_recover_after_route_deletion_disable_and_restart() {
     let (mut config, provider, model) = router_config("https://relay.example/v1".into());
     for legacy in ["codey", "old/relay"] {


### PR DESCRIPTION
## Problem

The 1.0.1 Windows build could stop Codey while waiting for Codex startup compatibility. It also rejected an unqualified model when the same upstream model was enabled on more than one route, even when the active Codey route was clear.

## What changed

- Restore the proven Windows startup order: Inspector first, then the CLI compatibility wrapper.
- Avoid the Windows `NODE_OPTIONS --require` startup path that caused the startup handoff regression.
- Resolve an unqualified model through the active route when that route explicitly enables the model and no route metadata is present.
- Keep explicit route metadata and existing session bindings higher priority than the active-route fallback.
- Preserve the existing API-key and endpoint pairing fix.

## Validation

- `cargo check --workspace` passed.
- The ambiguous-model active-route regression test passed.
- The Windows startup-exit regression test passed.
- Release build completed successfully.
- `git diff --check` passed.

The change is limited to the launcher and local-router code plus focused regression tests.
